### PR TITLE
fix: changed Makefile to setup without sudo permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ reset:
 
 # Install dependencies, download build resources and add pre-commit hook
 setup:
+	export GEM_HOME=$(HOME)/.gem
+	export PATH=$(GEM_HOME)/bin:$(PATH)
 	gem install cocoapods -v 1.9.1
 	brew bundle
 	eval "$$add_pre_commit_script"


### PR DESCRIPTION
According to Cocoapods guidelines and to make the installing process easier i added two path exports to change the default Gem installation folder