### PR TITLE
fix: privacy view not scrolling

### DIFF
--- a/App/UI/Privacy/PrivacyVC.swift
+++ b/App/UI/Privacy/PrivacyVC.swift
@@ -79,7 +79,7 @@ final class PrivacyVC: ViewControllerWithLocalState<PrivacyView> {
 
     guard
       let cell = checkBoxCell,
-      cell.convert(cell.bounds.origin, to: nil).y < self.rootView.frame.height
+      cell.convert(cell.bounds.origin, to: nil).y + cell.bounds.size.height < self.rootView.frame.height - self.rootView.scrollableGradientView.bounds.size.height
       else {
         let items = self.viewModel?.items.count ?? 0
         self.rootView.contentCollection.scrollToItem(at: IndexPath(item: items - 1, section: 0), at: .bottom, animated: true)

--- a/App/UI/Privacy/PrivacyVC.swift
+++ b/App/UI/Privacy/PrivacyVC.swift
@@ -79,7 +79,8 @@ final class PrivacyVC: ViewControllerWithLocalState<PrivacyView> {
 
     guard
       let cell = checkBoxCell,
-      cell.convert(cell.bounds.origin, to: nil).y + cell.bounds.size.height < self.rootView.frame.height - self.rootView.scrollableGradientView.bounds.size.height
+      cell.convert(cell.bounds.origin, to: nil).y + cell.bounds.size.height <
+        self.rootView.frame.height - self.rootView.scrollableGradientView.bounds.size.height
       else {
         let items = self.viewModel?.items.count ?? 0
         self.rootView.contentCollection.scrollToItem(at: IndexPath(item: items - 1, section: 0), at: .bottom, animated: true)

--- a/App/UI/Privacy/PrivacyView.swift
+++ b/App/UI/Privacy/PrivacyView.swift
@@ -52,7 +52,7 @@ final class PrivacyView: UIView, ViewControllerModellableView {
   private var actionButton = ButtonWithInsets()
 
   private let backgroundGradientView = GradientView()
-  private let scrollableGradientView = GradientView()
+  let scrollableGradientView = GradientView()
 
   private let headerView = UIView()
   private let headerTitleView = UILabel()


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

Fixes the calculated coordinates offset for the cell containing the privacy checkmarks.
The view doesn't scroll appropriately (on iPhone 11 and similar devices).

This PR tackles:

- Fixes privacy view scroll position

In particular, the ...

- Exposes the `scrollableGradientView` instance to other classes.
- To calculate checkmark cell visibility we consider its bottom position (not top) and that part of the collection view is covered by the aforementioned `scrollableGradientView`.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

<!-- Please insert the issue numbers after the # symbol -->

- Fixes #11 