### PR TITLE
feat: remove today var

### DIFF
--- a/App/Application/AppDelegate.swift
+++ b/App/Application/AppDelegate.swift
@@ -157,9 +157,6 @@ extension AppDelegate {
       .onNotification(UIApplication.didBecomeActiveNotification, [
         Logic.Lifecycle.DidBecomeActive.self
       ]),
-      .onNotification(UIApplication.significantTimeChangeNotification, [
-        Logic.Lifecycle.SignificantTimeChange.self
-      ]),
       .onStateChange(Logic.ForceUpdate.minimumAppVersionDidChange, [
         Logic.ForceUpdate.CheckAppVersion.self
       ])

--- a/App/Dependencies/AppDependencies+DebugMenu.swift
+++ b/App/Dependencies/AppDependencies+DebugMenu.swift
@@ -106,7 +106,7 @@
         .init(
           title: "🎮 [Status] Simulate Recover Confirmed",
           dispatchable: Logic.CovidStatus.UpdateStatusWithEvent(event: .userEvent(.recoverConfirmed))
-        ),
+        )
       ])
 
       // analytics

--- a/App/Dependencies/AppDependencies+DebugMenu.swift
+++ b/App/Dependencies/AppDependencies+DebugMenu.swift
@@ -107,14 +107,6 @@
           title: "🎮 [Status] Simulate Recover Confirmed",
           dispatchable: Logic.CovidStatus.UpdateStatusWithEvent(event: .userEvent(.recoverConfirmed))
         ),
-
-        .init(
-          title: "🎮 Simulate 1 Day Passed (until next app close/open)",
-          closure: {
-            let now = self.getAppState().environment.today
-            _ = self.dispatch(Logic.Shared.UpdateToday(today: now.byAdding(days: 1)))
-          }
-        )
       ])
 
       // analytics

--- a/App/Logic/LifecycleLogic.swift
+++ b/App/Logic/LifecycleLogic.swift
@@ -42,10 +42,6 @@ extension Logic {
         // refresh statuses
         try context.awaitDispatch(Logic.Lifecycle.RefreshAuthorizationStatuses())
 
-        // update today variable
-        let now = context.dependencies.now()
-        try context.awaitDispatch(Logic.Shared.UpdateToday(today: now.calendarDay))
-
         // clears `PositiveExposureResults` older than 14 days from the `ExposureDetectionState`
         try context.awaitDispatch(Logic.ExposureDetection.ClearOutdatedResults(now: context.dependencies.now()))
 
@@ -71,10 +67,6 @@ extension Logic {
       func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
         // refresh statuses
         try context.awaitDispatch(RefreshAuthorizationStatuses())
-
-        // update today variable
-        let now = context.dependencies.now()
-        try context.awaitDispatch(Logic.Shared.UpdateToday(today: now.calendarDay))
 
         // clears `PositiveExposureResults` older than 14 days from the `ExposureDetectionState`
         try context.awaitDispatch(Logic.ExposureDetection.ClearOutdatedResults(now: context.dependencies.now()))
@@ -107,30 +99,11 @@ extension Logic {
         // refresh statuses
         try context.awaitDispatch(RefreshAuthorizationStatuses())
 
-        // update today variable
-        let now = context.dependencies.now()
-        try context.awaitDispatch(Logic.Shared.UpdateToday(today: now.calendarDay))
-
         // update analaytics info
         try context.awaitDispatch(Logic.Analytics.UpdateOpportunityWindowIfNeeded())
 
         // Perform exposure detection if necessary
         context.dispatch(Logic.ExposureDetection.PerformExposureDetectionIfNecessary(type: .foreground))
-      }
-    }
-
-    /// Launched when there is a significant change in time, for example, change to a new day.
-    struct SignificantTimeChange: AppSideEffect, NotificationObserverDispatchable {
-      init?(notification: Notification) {
-        guard notification.name == UIApplication.significantTimeChangeNotification else {
-          return nil
-        }
-      }
-
-      func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
-        // update today variable
-        let now = context.dependencies.now()
-        try context.awaitDispatch(Logic.Shared.UpdateToday(today: now.calendarDay))
       }
     }
 
@@ -140,10 +113,6 @@ extension Logic {
       var task: BGTask
 
       func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
-        // update today variable
-        let now = context.dependencies.now()
-        try context.awaitDispatch(Logic.Shared.UpdateToday(today: now.calendarDay))
-
         // clears `PositiveExposureResults` older than 14 days from the `ExposureDetectionState`
         try context.awaitDispatch(Logic.ExposureDetection.ClearOutdatedResults(now: context.dependencies.now()))
 

--- a/App/Logic/SharedLogic.swift
+++ b/App/Logic/SharedLogic.swift
@@ -63,15 +63,6 @@ extension Logic.Shared {
     }
   }
 
-  /// Update today environment variable
-  struct UpdateToday: AppStateUpdater {
-    let today: CalendarDay
-
-    func updateState(_ state: inout AppState) {
-      state.environment.today = self.today
-    }
-  }
-
   struct OpenSettings: AppSideEffect {
     func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
       guard let url = URL(string: UIApplication.openSettingsURLString) else {

--- a/App/State/EnvironmentState.swift
+++ b/App/State/EnvironmentState.swift
@@ -41,9 +41,6 @@ struct EnvironmentState {
 
   /// The user's language
   var userLanguage: UserLanguage = .english
-
-  /// The current day
-  var today: CalendarDay = Date().calendarDay
 }
 
 // MARK: - Keyboard State


### PR DESCRIPTION
## Description

This PR removes the `today` variable from the app state, that, as a consequence of #12, is not anymore used.

This PR tackles:

- remove today variable
- remove lifecycle logic that handled the var updates

In particular, the ...

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Note

Check diff after merge of #12.