### PR TITLE
(fix): Changed Makefile to solve "Unknown command" Error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ reset:
 # Install dependencies, download build resources and add pre-commit hook
 setup:
 	gem install cocoapods -v 1.9.1
+	brew tap homebrew/bundle
 	brew bundle
 	eval "$$add_pre_commit_script"
 


### PR DESCRIPTION
## Description

<!--- Describe in detail the proposed mods -->

This PR tackles:

- Error when launching ```make setup``` command on a freshly installed brew

In particular, the command `make setup` failed with the ```error: Error: Unknown command: bundle``` if the "homebrew/bundle" tap was not installed on the machine (does not come preinstalled on basic brew installation).

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
