### PR TITLE
feat: hide sensitive data

### DIFF
--- a/App/Application/AppDelegate.swift
+++ b/App/Application/AppDelegate.swift
@@ -157,6 +157,9 @@ extension AppDelegate {
       .onNotification(UIApplication.didBecomeActiveNotification, [
         Logic.Lifecycle.DidBecomeActive.self
       ]),
+      .onNotification(UIApplication.willResignActiveNotification, [
+        Logic.Lifecycle.WillResignActive.self
+      ]),
       .onStateChange(Logic.ForceUpdate.minimumAppVersionDidChange, [
         Logic.ForceUpdate.CheckAppVersion.self
       ])

--- a/App/Application/AppNavigation.swift
+++ b/App/Application/AppNavigation.swift
@@ -29,6 +29,7 @@ enum Screen: String, CaseIterable {
 
   // main
   case tabBar
+  case sensitiveDataCover
 
   // common
   case loading
@@ -189,6 +190,13 @@ extension TabbarVC: RoutableWithConfiguration {
 
   var navigationConfiguration: [NavigationRequest: NavigationInstruction] {
     return [
+      // Sensitive Data Cover
+      .show(Screen.sensitiveDataCover): .presentModally { [unowned self] _ in
+        let vc = SensitiveDataCoverVC(store: self.store)
+        vc.modalPresentationStyle = .overFullScreen
+        return vc
+      },
+
       // Loading
       .show(Screen.loading): .presentModally { [unowned self] context in
         let ls = context as? LoadingLS ?? AppLogger.fatalError("Invalid context")
@@ -234,6 +242,20 @@ extension TabbarVC: RoutableWithConfiguration {
         SuggestionsVC(store: self.store, localState: SuggestionsLS())
       },
       .hide(Screen.suggestions): .dismissModally(behaviour: .hard)
+    ]
+  }
+}
+
+// MARK: SensitiveDataCover
+
+extension SensitiveDataCoverVC: RoutableWithConfiguration {
+  var routeIdentifier: RouteElementIdentifier {
+    return Screen.sensitiveDataCover.rawValue
+  }
+
+  var navigationConfiguration: [NavigationRequest: NavigationInstruction] {
+    return [
+      .hide(Screen.sensitiveDataCover): .dismissModally(behaviour: .soft)
     ]
   }
 }

--- a/App/Application/AppNavigation.swift
+++ b/App/Application/AppNavigation.swift
@@ -194,6 +194,7 @@ extension TabbarVC: RoutableWithConfiguration {
       .show(Screen.sensitiveDataCover): .presentModally { [unowned self] _ in
         let vc = SensitiveDataCoverVC(store: self.store)
         vc.modalPresentationStyle = .overFullScreen
+        vc.modalTransitionStyle = .crossDissolve
         return vc
       },
 

--- a/App/Logic/LifecycleLogic.swift
+++ b/App/Logic/LifecycleLogic.swift
@@ -96,7 +96,7 @@ extension Logic {
       }
 
       func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
-        // dismiss sensitive data overlay
+        // dismiss sensitive data overlay. Check `SensitiveDataCoverVC` documentation.
         context.dispatch(Logic.Shared.HideSensitiveDataCoverIfPresent())
 
         // refresh statuses
@@ -119,7 +119,7 @@ extension Logic {
       }
 
       func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
-        // show sensitive data overlay
+        // show sensitive data overlay. Check `SensitiveDataCoverVC` documentation.
         context.dispatch(Logic.Shared.ShowSensitiveDataCoverIfNeeded())
       }
     }

--- a/App/Logic/LifecycleLogic.swift
+++ b/App/Logic/LifecycleLogic.swift
@@ -96,6 +96,9 @@ extension Logic {
       }
 
       func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
+        // dismiss sensitive data overlay
+        context.dispatch(Logic.Shared.HideSensitiveDataCoverIfPresent())
+
         // refresh statuses
         try context.awaitDispatch(RefreshAuthorizationStatuses())
 
@@ -104,6 +107,20 @@ extension Logic {
 
         // Perform exposure detection if necessary
         context.dispatch(Logic.ExposureDetection.PerformExposureDetectionIfNecessary(type: .foreground))
+      }
+    }
+
+    /// Launched when app will resign active.
+    struct WillResignActive: AppSideEffect, NotificationObserverDispatchable {
+      init?(notification: Notification) {
+        guard notification.name == UIApplication.willResignActiveNotification else {
+          return nil
+        }
+      }
+
+      func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
+        // show sensitive data overlay
+        context.dispatch(Logic.Shared.ShowSensitiveDataCoverIfNeeded())
       }
     }
 

--- a/App/Logic/SharedLogic.swift
+++ b/App/Logic/SharedLogic.swift
@@ -63,6 +63,28 @@ extension Logic.Shared {
     }
   }
 
+  /// Show sensitive data cover.
+  struct ShowSensitiveDataCoverIfNeeded: AppSideEffect {
+    func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
+      let possiblePresenters: [String] = [Screen.tabBar.rawValue, Screen.onboardingStep.rawValue]
+      guard
+        context.dependencies.application.currentRoutableIdentifiers.contains(where: { possiblePresenters.contains($0) }) else {
+          return
+      }
+      context.dispatch(Show(Screen.sensitiveDataCover))
+    }
+  }
+
+  /// Hide sensitive data cover.
+  struct HideSensitiveDataCoverIfPresent: AppSideEffect {
+    func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
+      guard context.dependencies.application.currentRoutableIdentifiers.contains(Screen.sensitiveDataCover.rawValue) else {
+        return
+      }
+      context.dispatch(Hide(Screen.sensitiveDataCover))
+    }
+  }
+
   struct OpenSettings: AppSideEffect {
     func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
       guard let url = URL(string: UIApplication.openSettingsURLString) else {

--- a/App/Logic/SharedLogic.swift
+++ b/App/Logic/SharedLogic.swift
@@ -71,7 +71,7 @@ extension Logic.Shared {
         context.dependencies.application.currentRoutableIdentifiers.contains(where: { possiblePresenters.contains($0) }) else {
           return
       }
-      context.dispatch(Show(Screen.sensitiveDataCover))
+      context.dispatch(Show(Screen.sensitiveDataCover, animated: true))
     }
   }
 
@@ -81,7 +81,7 @@ extension Logic.Shared {
       guard context.dependencies.application.currentRoutableIdentifiers.contains(Screen.sensitiveDataCover.rawValue) else {
         return
       }
-      context.dispatch(Hide(Screen.sensitiveDataCover))
+      context.dispatch(Hide(Screen.sensitiveDataCover, animated: true))
     }
   }
 

--- a/App/UI/Onboarding/OnboardingContainer/OnboardingContainerNC.swift
+++ b/App/UI/Onboarding/OnboardingContainer/OnboardingContainerNC.swift
@@ -59,6 +59,7 @@ class OnboardingContainerNC: UINavigationController {
       .show(Screen.sensitiveDataCover): .presentModally { [unowned self] _ in
         let vc = SensitiveDataCoverVC(store: self.store)
         vc.modalPresentationStyle = .overFullScreen
+        vc.modalTransitionStyle = .crossDissolve
         return vc
       },
 

--- a/App/UI/Onboarding/OnboardingContainer/OnboardingContainerNC.swift
+++ b/App/UI/Onboarding/OnboardingContainer/OnboardingContainerNC.swift
@@ -56,6 +56,12 @@ class OnboardingContainerNC: UINavigationController {
 
   var navigationConfiguration: [NavigationRequest: NavigationInstruction] {
     return [
+      .show(Screen.sensitiveDataCover): .presentModally { [unowned self] _ in
+        let vc = SensitiveDataCoverVC(store: self.store)
+        vc.modalPresentationStyle = .overFullScreen
+        return vc
+      },
+
       .show(Screen.onboardingStep): .custom { _, _, animated, context, completion in
         let navContext = context as? OnboardingContainerNC.NavigationContext ?? AppLogger.fatalError("Invalid Context")
         self.pushViewController(using: navContext, animated: animated)

--- a/App/UI/SensitiveDataCover/SensitiveDataCover.swift
+++ b/App/UI/SensitiveDataCover/SensitiveDataCover.swift
@@ -1,0 +1,50 @@
+// SensitiveDataCover.swift
+// Copyright (C) 2020 Presidenza del Consiglio dei Ministri.
+// Please refer to the AUTHORS file for more information.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import Foundation
+import Tempura
+
+class SensitiveDataCoverVC: ViewController<SensitiveDataCoverView> {}
+
+struct SensitiveDataCoverVM: ViewModelWithState {}
+
+extension SensitiveDataCoverVM {
+  init(state: AppState) {}
+}
+
+// MARK: - View
+
+class SensitiveDataCoverView: UIVisualEffectView, ViewControllerModellableView {
+  typealias VM = SensitiveDataCoverVM
+
+  // MARK: - Setup
+
+  func setup() {}
+
+  // MARK: - Style
+
+  func style() {
+    self.effect = UIBlurEffect(style: .light)
+  }
+
+  // MARK: - Update
+
+  func update(oldModel: VM?) {}
+
+  // MARK: - Layout
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+  }
+}

--- a/App/UI/SensitiveDataCover/SensitiveDataCover.swift
+++ b/App/UI/SensitiveDataCover/SensitiveDataCover.swift
@@ -15,6 +15,10 @@
 import Foundation
 import Tempura
 
+/// This screen is a blur cover of the app's screen and is meant to be used when the app becomes inactive or goes to background
+/// while it's presenting sensitive data.
+/// This is done to avoid a possible low-level malware to access the screenshots that are stored by the OS to implement the
+/// multi-tasking functionality.
 class SensitiveDataCoverVC: ViewController<SensitiveDataCoverView> {}
 
 struct SensitiveDataCoverVM: ViewModelWithState {}


### PR DESCRIPTION
## Description

This PR adds a blur cover to the app's screen when the app becomes inactive / goes to background.
This is done to avoid a possible low-level malware to access the screenshots that are stored by the OS to implement the multi-tasking functionality. 

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

- Fixes #21

## Note

No UITests are added for the new vc as it's just a UIVisualEffectView with a blur effect. Consider to add them if the view becomes more complex.