### PR TITLE
fix: update error codes

### DIFF
--- a/Modules/Networking/Core/NetworkManager.swift
+++ b/Modules/Networking/Core/NetworkManager.swift
@@ -110,10 +110,8 @@ public extension NetworkManager {
     case bodyNotCompliant = 1002
     /// Raised when a request to upload a bunch of keys contains too many keys.
     case tooManyKeysUploaded = 1101
-    /// Raised when the province code sent is not valid.
-    case provinceNotValid = 1102
     /// Raised when a user is attempting to upload data with an unauthorised OTP code.
-    case unauthorizedOTP = 1103
+    case unauthorizedOTP = 1102
     /// Exception raised when the requested batch is not found.
     case batchNotFound = 1301
     /// Exception raised when there are no batches.


### PR DESCRIPTION
## Description

Backend error codes did change.
`400 | 1102 | Province is invalid.` dropped and fallback to `400 | 1002 | Request not compliant with the defined schema.`
`401 | 1103 | Unauthorised OTP.` code changed from `1103` to `1102`

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
