### PR TITLE
fix: rename MigratioLog.swift to MigrationLog.swift

### DIFF
--- a/Modules/StorePersistence/Migrations/MigrationLog.swift
+++ b/Modules/StorePersistence/Migrations/MigrationLog.swift
@@ -1,4 +1,4 @@
-// MigratioLog.swift
+// MigrationLog.swift
 // Copyright (C) 2020 Presidenza del Consiglio dei Ministri.
 // Please refer to the AUTHORS file for more information.
 // This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Description

Just fix typo in file `MigratioLog.swift` that should really be `MigrationLog.swift`

This PR tackles:

- fixed the name of the file to the intended one.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

<!-- Please insert the issue numbers after the # symbol -->

- Fixes #32
