### PR TITLE
fix: sticky cell frame had wrong origin on scroll

### DIFF
--- a/App/UI/Shared/CollectionViewLayouts/CollectionWithStickyHeaderLayout.swift
+++ b/App/UI/Shared/CollectionViewLayouts/CollectionWithStickyHeaderLayout.swift
@@ -58,10 +58,7 @@ class CollectionWithStickyCellsLayout: UICollectionViewFlowLayout {
         frame.size.height = max(cellMinimumHeight, cellStandardHeight - offset.y)
         frame.origin.y = frame.minY + offset.y
 
-        if frame != cellAttributes.frame {
-          cellAttributes.frame = frame
-          cell.frame = frame
-        }
+        cell.frame = frame
       }
     }
 


### PR DESCRIPTION


<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

The error was probably due to a CGFloat approximation error and delays in layoutAttributesForElements calls

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

<!-- Please insert the issue numbers after the # symbol -->

- Fixes #36
