### PR TITLE
feat: how it works cta

### DIFF
--- a/App/Logic/PermissionTutorialLogic.swift
+++ b/App/Logic/PermissionTutorialLogic.swift
@@ -35,12 +35,13 @@ extension Logic.PermissionTutorial {
 
   /// Shows the how immuni works page
   struct ShowHowImmuniWorks: AppSideEffect {
+    let showFaqButton: Bool
     func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
       try context
         .awaitDispatch(Show(
           Screen.permissionTutorial,
           animated: true,
-          context: PermissionTutorialLS(content: .howImmuniWorks)
+          context: PermissionTutorialLS(content: .howImmuniWorks(shouldShowFaqButton: self.showFaqButton))
         ))
     }
   }

--- a/App/UI/Home/HomeVC.swift
+++ b/App/UI/Home/HomeVC.swift
@@ -46,7 +46,7 @@ class HomeVC: ViewController<HomeView> {
   func handleDidTapInfo(_ info: HomeVM.InfoKind) {
     switch info {
     case .app:
-      self.dispatch(Logic.PermissionTutorial.ShowHowImmuniWorks())
+      self.dispatch(Logic.PermissionTutorial.ShowHowImmuniWorks(showFaqButton: true))
 
     case .protection:
       self.dispatch(Logic.Suggestions.ShowSuggestions())

--- a/App/UI/Onboarding/Permission/OnboardingPermissionVC.swift
+++ b/App/UI/Onboarding/Permission/OnboardingPermissionVC.swift
@@ -22,7 +22,7 @@ final class OnboardingPermissionVC: ViewControllerWithLocalState<OnboardingPermi
 
   override func setupInteraction() {
     self.rootView.userDidTapDiscoverMore = { [weak self] in
-      self?.store.dispatch(Logic.PermissionTutorial.ShowHowImmuniWorks())
+      self?.store.dispatch(Logic.PermissionTutorial.ShowHowImmuniWorks(showFaqButton: false))
     }
 
     self.rootView.userDidTapClose = { [weak self] in

--- a/App/UI/PermissionTutorial/PermissionTutorialVM.swift
+++ b/App/UI/PermissionTutorial/PermissionTutorialVM.swift
@@ -227,57 +227,66 @@ extension PermissionTutorialVM.Content {
     )
   }
 
-  static var howImmuniWorks: Self {
-    return PermissionTutorialVM.Content(
-      title: L10n.PermissionTutorial.HowImmuniWorks.title,
-      items: [
-        .spacer(.big),
-        .imageContent(Asset.HowImmuniWorks.visual1.image),
-        .spacer(.medium),
-        .textualContent(L10n.PermissionTutorial.HowImmuniWorks.First.title),
-        .spacer(.tiny),
-        .textualContent(L10n.PermissionTutorial.HowImmuniWorks.First.message),
-        .spacer(.medium),
-        .imageContent(Asset.HowImmuniWorks.break.image),
-        .spacer(.big),
-        .imageContent(Asset.HowImmuniWorks.visual2.image),
-        .spacer(.medium),
-        .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Second.title),
-        .spacer(.tiny),
-        .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Second.message),
-        .spacer(.medium),
-        .imageContent(Asset.HowImmuniWorks.break.image),
-        .spacer(.big),
-        .imageContent(Asset.HowImmuniWorks.visual3.image),
-        .spacer(.medium),
-        .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Third.title),
-        .spacer(.tiny),
-        .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Third.message),
-        .spacer(.medium),
-        .imageContent(Asset.HowImmuniWorks.break.image),
-        .spacer(.big),
-        .imageContent(Asset.HowImmuniWorks.visual4.image),
-        .spacer(.medium),
-        .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Fourth.title),
-        .spacer(.tiny),
-        .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Fourth.message),
-        .spacer(.medium),
-        .imageContent(Asset.HowImmuniWorks.break.image),
-        .spacer(.big),
-        .imageContent(Asset.HowImmuniWorks.visual5.image),
-        .spacer(.medium),
-        .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Fifth.title),
-        .spacer(.tiny),
-        .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Fifth.message),
-        .spacer(.medium),
+  static func howImmuniWorks(shouldShowFaqButton: Bool) -> Self {
+    var items: [Item] = [
+      .spacer(.big),
+      .imageContent(Asset.HowImmuniWorks.visual1.image),
+      .spacer(.medium),
+      .textualContent(L10n.PermissionTutorial.HowImmuniWorks.First.title),
+      .spacer(.tiny),
+      .textualContent(L10n.PermissionTutorial.HowImmuniWorks.First.message),
+      .spacer(.medium),
+      .imageContent(Asset.HowImmuniWorks.break.image),
+      .spacer(.big),
+      .imageContent(Asset.HowImmuniWorks.visual2.image),
+      .spacer(.medium),
+      .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Second.title),
+      .spacer(.tiny),
+      .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Second.message),
+      .spacer(.medium),
+      .imageContent(Asset.HowImmuniWorks.break.image),
+      .spacer(.big),
+      .imageContent(Asset.HowImmuniWorks.visual3.image),
+      .spacer(.medium),
+      .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Third.title),
+      .spacer(.tiny),
+      .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Third.message),
+      .spacer(.medium),
+      .imageContent(Asset.HowImmuniWorks.break.image),
+      .spacer(.big),
+      .imageContent(Asset.HowImmuniWorks.visual4.image),
+      .spacer(.medium),
+      .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Fourth.title),
+      .spacer(.tiny),
+      .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Fourth.message),
+      .spacer(.medium),
+      .imageContent(Asset.HowImmuniWorks.break.image),
+      .spacer(.big),
+      .imageContent(Asset.HowImmuniWorks.visual5.image),
+      .spacer(.medium),
+      .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Fifth.title),
+      .spacer(.tiny),
+      .textualContent(L10n.PermissionTutorial.HowImmuniWorks.Fifth.message),
+      .spacer(.medium)
+    ]
+    var action: Dispatchable?
+
+    if shouldShowFaqButton {
+      items.append(contentsOf: [
         .scrollableButton(
           description: L10n.PermissionTutorial.HowImmuniWorks.Action.description,
           buttonTitle: L10n.PermissionTutorial.HowImmuniWorks.Action.cta
         ),
         .spacer(.medium)
-      ],
+      ])
+      action = Logic.Settings.ShowFAQs()
+    }
+
+    return PermissionTutorialVM.Content(
+      title: L10n.PermissionTutorial.HowImmuniWorks.title,
+      items: items,
       mainActionTitle: nil,
-      action: Logic.Settings.ShowFAQs()
+      action: action
     )
   }
 }

--- a/App/UI/Welcome/WelcomeVC.swift
+++ b/App/UI/Welcome/WelcomeVC.swift
@@ -41,7 +41,7 @@ class WelcomeVC: ViewControllerWithLocalState<WelcomeView> {
     }
 
     self.rootView.didTapDiscoverMore = { [weak self] in
-      self?.store.dispatch(Logic.PermissionTutorial.ShowHowImmuniWorks())
+      self?.store.dispatch(Logic.PermissionTutorial.ShowHowImmuniWorks(showFaqButton: false))
     }
   }
 }

--- a/UITests/PermissionTutorial/PermissionTutorialUITests.swift
+++ b/UITests/PermissionTutorial/PermissionTutorialUITests.swift
@@ -35,7 +35,8 @@ class PermissionTutorialUITests: AppViewTestCase, ViewTestCase {
           isHeaderVisible: false
         ),
         "permission_tutorial_update_os": PermissionTutorialVM(content: .updateOperatingSystem, isHeaderVisible: false),
-        "how_immuni_works": PermissionTutorialVM(content: .howImmuniWorks, isHeaderVisible: false)
+        "how_immuni_works": PermissionTutorialVM(content: .howImmuniWorks(shouldShowFaqButton: false), isHeaderVisible: false),
+        "how_immuni_works_faq": PermissionTutorialVM(content: .howImmuniWorks(shouldShowFaqButton: true), isHeaderVisible: false)
       ],
       context: context
     )
@@ -71,7 +72,14 @@ class PermissionTutorialUITests: AppViewTestCase, ViewTestCase {
           isHeaderVisible: true
         ),
         "permission_tutorial_update_os_scrolled": PermissionTutorialVM(content: .updateOperatingSystem, isHeaderVisible: true),
-        "how_immuni_works_scrolled": PermissionTutorialVM(content: .howImmuniWorks, isHeaderVisible: true)
+        "how_immuni_works_scrolled": PermissionTutorialVM(
+          content: .howImmuniWorks(shouldShowFaqButton: false),
+          isHeaderVisible: true
+        ),
+        "how_immuni_works_faq_scrolled": PermissionTutorialVM(
+          content: .howImmuniWorks(shouldShowFaqButton: true),
+          isHeaderVisible: true
+        )
       ],
       context: context
     )


### PR DESCRIPTION
## Description

This PR adds the CTA button in the `How it works` screen only when needed.
According to the product team the CTA button that brings to FAQ should be visible only when the screen is presented from the Home tab.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

- Addresses #35
