### PR TITLE
feat: diagnosis key permission overlay

### DIFF
--- a/App/Logic/DataUploadLogic.swift
+++ b/App/Logic/DataUploadLogic.swift
@@ -103,7 +103,7 @@ extension Logic.DataUpload {
         .awaitDispatch(Show(
           Screen.permissionOverlay,
           animated: true,
-          context: OnboardingPermissionOverlayLS(type: .exposureNotification)
+          context: OnboardingPermissionOverlayLS(type: .diagnosisKeys)
         ))
 
       let keys: [TemporaryExposureKey]

--- a/App/Logic/SharedLogic.swift
+++ b/App/Logic/SharedLogic.swift
@@ -73,6 +73,11 @@ extension Logic.Shared {
         .contains(where: { Self.possiblePresenters.contains($0) }) else {
           return
       }
+      // avoid to cover permission overlay screen when presenting native permission alert.
+      guard !context.dependencies.application.currentRoutableIdentifiers.contains(Screen.permissionOverlay.rawValue) else {
+        return
+      }
+
       context.dispatch(Show(Screen.sensitiveDataCover, animated: true))
     }
   }

--- a/App/Resources/de.lproj/Localizable.strings
+++ b/App/Resources/de.lproj/Localizable.strings
@@ -177,6 +177,7 @@
 "upload_data.vpn_error.title" = "Qualcosa è andato storto";
 "upload_data.vpn_error.message" = "Si è verificato un errore durante l’operazione. Ti invitiamo a riprovare. Se stai utilizzando una VPN, ti suggeriamo di selezionare un server europeo o di disabilitarla temporaneamente.";
 "upload_data.vpn_error.action" = "OK";
+"upload_data.diagnosis_keys.overlay.hint" = "Seleziona \"<b>Condividi</b>\" nel popup che apparirà qui sotto";
 
 "confirm_data.title" = "Ecco i dati che verranno caricati";
 "confirm_data.footer_message" = "Attendi conferma da parte dell'operatore per caricare i tuoi dati.";

--- a/App/Resources/en-GB.lproj/Localizable.strings
+++ b/App/Resources/en-GB.lproj/Localizable.strings
@@ -177,6 +177,7 @@
 "upload_data.vpn_error.title" = "Qualcosa è andato storto";
 "upload_data.vpn_error.message" = "Si è verificato un errore durante l’operazione. Ti invitiamo a riprovare. Se stai utilizzando una VPN, ti suggeriamo di selezionare un server europeo o di disabilitarla temporaneamente.";
 "upload_data.vpn_error.action" = "OK";
+"upload_data.diagnosis_keys.overlay.hint" = "Seleziona \"<b>Condividi</b>\" nel popup che apparirà qui sotto";
 
 "confirm_data.title" = "Ecco i dati che verranno caricati";
 "confirm_data.footer_message" = "Attendi conferma da parte dell'operatore per caricare i tuoi dati.";

--- a/App/Resources/it.lproj/Localizable.strings
+++ b/App/Resources/it.lproj/Localizable.strings
@@ -177,6 +177,7 @@
 "upload_data.vpn_error.title" = "Qualcosa è andato storto";
 "upload_data.vpn_error.message" = "Si è verificato un errore durante l’operazione. Ti invitiamo a riprovare. Se stai utilizzando una VPN, ti suggeriamo di selezionare un server europeo o di disabilitarla temporaneamente.";
 "upload_data.vpn_error.action" = "OK";
+"upload_data.diagnosis_keys.overlay.hint" = "Seleziona \"<b>Condividi</b>\" nel popup che apparirà qui sotto";
 
 "confirm_data.title" = "Ecco i dati che verranno caricati";
 "confirm_data.footer_message" = "Attendi conferma da parte dell'operatore per caricare i tuoi dati.";

--- a/App/UI/Onboarding/PermissionOverlay/OnboardingPermissionOverlayVM.swift
+++ b/App/UI/Onboarding/PermissionOverlay/OnboardingPermissionOverlayVM.swift
@@ -27,6 +27,9 @@ struct OnboardingPermissionOverlayVM: Equatable {
 
     case .pushNotification:
       return L10n.Onboarding.PushPermission.Overlay.hint
+
+    case .diagnosisKeys:
+      return L10n.UploadData.DiagnosisKeys.Overlay.hint
     }
   }
 }
@@ -41,5 +44,6 @@ extension OnboardingPermissionOverlayVM {
   enum OverlayType {
     case exposureNotification
     case pushNotification
+    case diagnosisKeys
   }
 }

--- a/UITests/Onboarding/OnboardingPermissionOverlayUITests.swift
+++ b/UITests/Onboarding/OnboardingPermissionOverlayUITests.swift
@@ -24,7 +24,8 @@ class OnboardingPermissionOverlayUITests: AppViewTestCase, ViewTestCase {
     self.uiTest(
       testCases: [
         "onboarding_permission_overlay_exposure_notification": OnboardingPermissionOverlayVM(type: .exposureNotification),
-        "onboarding_permission_push_notification": OnboardingPermissionOverlayVM(type: .pushNotification)
+        "onboarding_permission_push_notification": OnboardingPermissionOverlayVM(type: .pushNotification),
+        "onboarding_permission_diagnosis_keys": OnboardingPermissionOverlayVM(type: .diagnosisKeys)
       ],
       context: UITests.Context<V>()
     )


### PR DESCRIPTION
## Description

This PR fixes the hint in the permission overlay in the data upload process.
Formally, it adds a copy to select the `Condividi` button in the diagnosis keys fetch authorization alert.
Also it fixes an issue when presenting the permission overlay screen to avoid to cover the screen with `SensitiveDataOverlayVC`.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
