### PR TITLE
feat: ensure all ingestion requests have the same size

### DIFF
--- a/App/Dependencies/AppDependencies+DebugMenu.swift
+++ b/App/Dependencies/AppDependencies+DebugMenu.swift
@@ -315,9 +315,9 @@
   /// Send all three possible Ingestion requests so that their padding can be tested end to end.
   private struct SendRequests: AppSideEffect {
     func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
-      context.dependencies.networkManager.validateOTP(OTP(), requestSize: 100_000)
-      context.dependencies.networkManager.uploadData(body: .mock(), otp: OTP(), requestSize: 100_000)
-      context.dependencies.networkManager.sendDummyIngestionRequest(requestSize: 100_000)
+      context.dependencies.networkManager.validateOTP(OTP(), requestSize: 100_000).run()
+      context.dependencies.networkManager.uploadData(body: .mock(), otp: OTP(), requestSize: 100_000).run()
+      context.dependencies.networkManager.sendDummyIngestionRequest(requestSize: 100_000).run()
     }
   }
 

--- a/App/Dependencies/AppDependencies+DebugMenu.swift
+++ b/App/Dependencies/AppDependencies+DebugMenu.swift
@@ -21,6 +21,7 @@
   import ImmuniExposureNotification
   import Katana
   import Models
+  import Networking
   import PushNotification
   import Tempura
 
@@ -137,6 +138,11 @@
         .init(
           title: "[Ingestion] Start simulated ingestion sequence",
           dispatchable: Logic.DataUpload.StartIngestionSequenceIfNotCancelled()
+        ),
+
+        .init(
+          title: "[Ingestion] Send all posts",
+          dispatchable: SendRequests()
         )
       ])
 
@@ -306,6 +312,15 @@
     }
   }
 
+  /// Send all three possible Ingestion requests so that their padding can be tested end to end.
+  private struct SendRequests: AppSideEffect {
+    func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
+      context.dependencies.networkManager.validateOTP(OTP(), requestSize: 100_000)
+      context.dependencies.networkManager.uploadData(body: .mock(), otp: OTP(), requestSize: 100_000)
+      context.dependencies.networkManager.sendDummyIngestionRequest(requestSize: 100_000)
+    }
+  }
+
   // MARK: - Debug Print helpers
 
   private extension DateFormatter {
@@ -359,4 +374,64 @@
       ].joined(separator: ", ")
     }
   }
+
+  // MARK: Ingestion-related mocks
+
+  private extension DataUploadRequest.Body {
+    static func mock() -> Self {
+      let teks = (0 ..< 14).map { _ in CodableTemporaryExposureKey.mock() }
+      let summaries = (0 ..< 30).map { _ in CodableExposureDetectionSummary.mock() }
+
+      return self.init(
+        teks: teks,
+        province: "AA",
+        exposureDetectionSummaries: summaries
+      )
+    }
+  }
+
+  private extension CodableTemporaryExposureKey {
+    static func mock() -> Self {
+      return .init(
+        keyData: Data.randomData(with: 168),
+        rollingStartNumber: Int(Date().timeIntervalSince1970 / 600),
+        rollingPeriod: 144
+      )
+    }
+  }
+
+  private extension CodableExposureInfo {
+    static func mock() -> Self {
+      return .init(
+        date: Date(),
+        duration: TimeInterval.random(in: 0 ... 1800),
+        attenuationValue: Int.random(in: 10 ... 100),
+        attenuationDurations: [
+          TimeInterval.random(in: 0 ... 1800),
+          TimeInterval.random(in: 0 ... 1800),
+          TimeInterval.random(in: 0 ... 1800)
+        ],
+        transmissionRiskLevel: Int.random(in: 1 ... 8),
+        totalRiskScore: Int.random(in: 1 ... 8)
+      )
+    }
+  }
+
+  private extension CodableExposureDetectionSummary {
+    static func mock() -> Self {
+      return .init(
+        date: Date(),
+        matchedKeyCount: Int.random(in: 0 ... 15),
+        daysSinceLastExposure: Int.random(in: 0 ... 14),
+        attenuationDurations: [
+          TimeInterval.random(in: 0 ... 1800),
+          TimeInterval.random(in: 0 ... 1800),
+          TimeInterval.random(in: 0 ... 1800)
+        ],
+        maximumRiskScore: Int.random(in: 0 ... 255),
+        exposureInfo: (0 ..< Int.random(in: 1 ... 10)).map { _ in CodableExposureInfo.mock() }
+      )
+    }
+  }
+
 #endif

--- a/App/Logic/DataUploadLogic+DummyTraffic.swift
+++ b/App/Logic/DataUploadLogic+DummyTraffic.swift
@@ -100,8 +100,9 @@ extension Logic.DataUpload {
           break
         }
 
-        #warning("Define proper dummy request")
-        try? await(context.dependencies.networkManager.uploadData(body: .dummy(), otp: .init()))
+        #warning("Take request size from configuration")
+        let requestSize = 200_000
+        try? await(context.dependencies.networkManager.sendDummyIngestionRequest(requestSize: requestSize))
 
         let diceRoll = context.dependencies.uniformDistributionGenerator.randomNumberBetweenZeroAndOne()
         let threshold = state.configuration.dummyIngestionRequestProbabilities[safe: executions]

--- a/App/Logic/DataUploadLogic+DummyTraffic.swift
+++ b/App/Logic/DataUploadLogic+DummyTraffic.swift
@@ -100,8 +100,7 @@ extension Logic.DataUpload {
           break
         }
 
-        #warning("Take request size from configuration")
-        let requestSize = 200_000
+        let requestSize = state.configuration.ingestionRequestTargetSize
         try? await(context.dependencies.networkManager.sendDummyIngestionRequest(requestSize: requestSize))
 
         let diceRoll = context.dependencies.uniformDistributionGenerator.randomNumberBetweenZeroAndOne()

--- a/App/Logic/DataUploadLogic.swift
+++ b/App/Logic/DataUploadLogic.swift
@@ -68,6 +68,7 @@ extension Logic.DataUpload {
     }
 
     func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
+      let state = context.getState()
       try context.awaitDispatch(Logic.Loading.Show(message: L10n.UploadData.Verify.loading))
 
       do {
@@ -80,8 +81,7 @@ extension Logic.DataUpload {
 
       do {
         // Send the request
-        #warning("Take request size from configuration")
-        let requestSize = 200_000
+        let requestSize = state.configuration.ingestionRequestTargetSize
         try await(context.dependencies.networkManager.validateOTP(self.code, requestSize: requestSize))
         try context.awaitDispatch(MarkOTPValidationSuccessfulAttempt())
       } catch NetworkManager.Error.unauthorizedOTP {
@@ -167,8 +167,7 @@ extension Logic.DataUpload {
 
       // Send the data to the backend
       do {
-        #warning("Take request size from configuration")
-        let requestSize = 200_000
+        let requestSize = state.configuration.ingestionRequestTargetSize
         try await(context.dependencies.networkManager.uploadData(body: requestBody, otp: self.code, requestSize: requestSize))
         try await(context.dispatch(Logic.Loading.Hide()))
       } catch {

--- a/App/Logic/DataUploadLogic.swift
+++ b/App/Logic/DataUploadLogic.swift
@@ -80,7 +80,9 @@ extension Logic.DataUpload {
 
       do {
         // Send the request
-        try await(context.dependencies.networkManager.validateOTP(self.code))
+        #warning("Take request size from configuration")
+        let requestSize = 200_000
+        try await(context.dependencies.networkManager.validateOTP(self.code, requestSize: requestSize))
         try context.awaitDispatch(MarkOTPValidationSuccessfulAttempt())
       } catch NetworkManager.Error.unauthorizedOTP {
         // User is not authorized. Bubble up the error to the calling ViewController
@@ -165,7 +167,9 @@ extension Logic.DataUpload {
 
       // Send the data to the backend
       do {
-        try await(context.dependencies.networkManager.uploadData(body: requestBody, otp: self.code))
+        #warning("Take request size from configuration")
+        let requestSize = 200_000
+        try await(context.dependencies.networkManager.uploadData(body: requestBody, otp: self.code, requestSize: requestSize))
         try await(context.dispatch(Logic.Loading.Hide()))
       } catch {
         try await(context.dispatch(Logic.Loading.Hide()))

--- a/AppTests/Networking/FixedSizeJsonRequestTests.swift
+++ b/AppTests/Networking/FixedSizeJsonRequestTests.swift
@@ -12,6 +12,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+// swiftlint:disable superfluous_disable_command force_try implicitly_unwrapped_optional force_unwrapping force_cast
+
 import Alamofire
 import Models
 import Networking

--- a/AppTests/Networking/FixedSizeJsonRequestTests.swift
+++ b/AppTests/Networking/FixedSizeJsonRequestTests.swift
@@ -1,0 +1,246 @@
+// FixedSizeJsonRequestTests.swift
+// Copyright (C) 2020 Presidenza del Consiglio dei Ministri.
+// Please refer to the AUTHORS file for more information.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import Alamofire
+import Models
+import Networking
+import XCTest
+
+class FixedSizeJsonRequestTests: XCTestCase {
+  func testRequestWithNoBodyAndNoHeadersHasGivenSize() throws {
+    let targetSize = 100_000
+    let request = try MockEmptyRequest(targetSize: targetSize).asURLRequest()
+
+    XCTAssertEqual(request.size, targetSize)
+  }
+
+  func testNumberOfHeadersDoesNotMatter() throws {
+    let headers: [HTTPHeader] = [
+      .acceptCharset("test"),
+      .authorization(bearerToken: "someToken"),
+      .userAgent("test3")
+    ]
+
+    let targetSize = 100_000
+    let request1 = try MockEmptyRequest(targetSize: targetSize, headers: Array(headers.prefix(1))).asURLRequest()
+    let request2 = try MockEmptyRequest(targetSize: targetSize, headers: Array(headers.prefix(2))).asURLRequest()
+    let request3 = try MockEmptyRequest(targetSize: targetSize, headers: Array(headers.prefix(3))).asURLRequest()
+
+    XCTAssertEqual(request1.size, targetSize)
+    XCTAssertEqual(request1.size, request2.size)
+    XCTAssertEqual(request1.size, request3.size)
+  }
+
+  func testBodyDoesNotMatter() throws {
+    let targetSize = 100_000
+    let request1 = try MockEmptyRequest(targetSize: targetSize).asURLRequest()
+    let request2 = try MockRequest(targetSize: targetSize, body: .init(string: "SomeString", int: 42, array: [true, false]))
+      .asURLRequest()
+    let request3 = try MockRequest(targetSize: targetSize, body: .init(string: "Some Other String", int: 0, array: []))
+      .asURLRequest()
+
+    XCTAssertEqual(request1.size, targetSize)
+    XCTAssertEqual(request1.size, request2.size)
+    XCTAssertEqual(request1.size, request3.size)
+  }
+
+  func testMethodDoesNotMatter() throws {
+    let targetSize = 100_000
+    let request1 = try MockEmptyRequest(targetSize: targetSize, method: .post).asURLRequest()
+    let request2 = try MockEmptyRequest(targetSize: targetSize, method: .connect).asURLRequest()
+    let request3 = try MockEmptyRequest(targetSize: targetSize, method: .get).asURLRequest()
+
+    XCTAssertEqual(request1.size, targetSize)
+    XCTAssertEqual(request1.size, request2.size)
+    XCTAssertEqual(request1.size, request3.size)
+  }
+
+  func testBaseURLDoesNotMatter() throws {
+    let targetSize = 100_000
+    let request1 = try MockEmptyRequest(targetSize: targetSize, baseURL: URL(string: "http://example.com")!).asURLRequest()
+    let request2 = try MockEmptyRequest(targetSize: targetSize, baseURL: URL(string: "https://example.com")!).asURLRequest()
+    let request3 = try MockEmptyRequest(targetSize: targetSize, baseURL: URL(string: "https://www.example.com")!).asURLRequest()
+
+    XCTAssertEqual(request1.size, targetSize)
+    XCTAssertEqual(request1.size, request2.size)
+    XCTAssertEqual(request1.size, request3.size)
+  }
+
+  func testPathDoesNotMatter() throws {
+    let targetSize = 100_000
+    let request1 = try MockEmptyRequest(targetSize: targetSize, path: "").asURLRequest()
+    let request2 = try MockEmptyRequest(targetSize: targetSize, path: "/some/endpoint").asURLRequest()
+    let request3 = try MockEmptyRequest(targetSize: targetSize, path: "/some/other/endpoint?query=1").asURLRequest()
+
+    XCTAssertEqual(request1.size, targetSize)
+    XCTAssertEqual(request1.size, request2.size)
+    XCTAssertEqual(request1.size, request3.size)
+  }
+
+  func testConcreteRequestsHaveSameSize() throws {
+    let targetSize = 50000
+
+    let teks = (0 ..< 14).map { _ in CodableTemporaryExposureKey.mock() }
+    let summaries = (0 ..< 30).map { _ in CodableExposureDetectionSummary.mock() }
+
+    let request1 = try DataUploadRequest(
+      body: .init(
+        teks: teks,
+        province: "AA",
+        exposureDetectionSummaries: summaries
+      ),
+      otp: OTP(),
+      now: { Date() },
+      targetSize: targetSize
+    ).asURLRequest()
+
+    let request2 = try OTPValidationRequest(otp: OTP(), now: { Date() }, targetSize: targetSize).asURLRequest()
+    let request3 = try DummyIngestionRequest(now: { Date() }, targetSize: targetSize).asURLRequest()
+
+    XCTAssertEqual(request1.size, targetSize)
+    XCTAssertEqual(request1.size, request2.size)
+    XCTAssertEqual(request1.size, request3.size)
+  }
+}
+
+// MARK: - Helpers
+
+private extension URLRequest {
+  var size: Int {
+    let bodySize = self.httpBody?.count ?? 0
+    let headersSize = self.headers.map { "\($0.name): \($0.value)\r\n" }.map { $0.data(using: .utf8)?.count ?? 0 }.reduce(0, +)
+    let methodSize = self.method?.rawValue.data(using: .utf8)?.count ?? 0
+    let urlSize = self.url?.absoluteString.data(using: .utf8)?.count ?? 0
+    return bodySize + headersSize + methodSize + urlSize
+  }
+}
+
+// MARK: - Mocks
+
+extension FixedSizeJsonRequestTests {
+  struct MockRequest: FixedSizeJSONRequest {
+    typealias BodyModel = Body
+
+    var targetSize: Int
+    var method: HTTPMethod
+    var baseURL: URL
+    var path: String
+    var headers: [HTTPHeader]
+
+    let jsonParameter: Body
+
+    init(
+      targetSize: Int,
+      method: HTTPMethod = .post,
+      baseURL: URL = URL(string: "https://example.com")!,
+      path: String = "/some/endpoint",
+      headers: [HTTPHeader] = [],
+      body: Body
+    ) {
+      self.targetSize = targetSize
+      self.method = method
+      self.baseURL = baseURL
+      self.path = path
+      self.headers = headers
+      self.jsonParameter = body
+    }
+
+    struct Body: Encodable {
+      let string: String
+      let int: Int
+      let array: [Bool]
+    }
+  }
+
+  struct MockEmptyRequest: FixedSizeJSONRequest {
+    typealias BodyModel = EmptyBody
+
+    var targetSize: Int
+    var method: HTTPMethod
+    var baseURL: URL
+    var path: String
+    var headers: [HTTPHeader]
+
+    init(
+      targetSize: Int,
+      method: HTTPMethod = .post,
+      baseURL: URL = URL(string: "https://example.com")!,
+      path: String = "/some/endpoint",
+      headers: [HTTPHeader] = []
+    ) {
+      self.targetSize = targetSize
+      self.method = method
+      self.baseURL = baseURL
+      self.path = path
+      self.headers = headers
+    }
+  }
+}
+
+private extension DataUploadRequest.Body {
+  static func mock() -> Self {
+    let teks = (0 ..< 14).map { _ in CodableTemporaryExposureKey.mock() }
+    let summaries = (0 ..< 30).map { _ in CodableExposureDetectionSummary.mock() }
+
+    return self.init(
+      teks: teks,
+      province: "AA",
+      exposureDetectionSummaries: summaries
+    )
+  }
+}
+
+private extension CodableTemporaryExposureKey {
+  static func mock() -> Self {
+    return .init(
+      keyData: Data.randomData(with: 168),
+      rollingStartNumber: Int(Date().timeIntervalSince1970 / 600),
+      rollingPeriod: 144
+    )
+  }
+}
+
+private extension CodableExposureInfo {
+  static func mock() -> Self {
+    return .init(
+      date: Date(),
+      duration: TimeInterval.random(in: 0 ... 1800),
+      attenuationValue: Int.random(in: 10 ... 100),
+      attenuationDurations: [
+        TimeInterval.random(in: 0 ... 1800),
+        TimeInterval.random(in: 0 ... 1800),
+        TimeInterval.random(in: 0 ... 1800)
+      ],
+      transmissionRiskLevel: Int.random(in: 1 ... 8),
+      totalRiskScore: Int.random(in: 1 ... 8)
+    )
+  }
+}
+
+private extension CodableExposureDetectionSummary {
+  static func mock() -> Self {
+    return .init(
+      date: Date(),
+      matchedKeyCount: Int.random(in: 0 ... 15),
+      daysSinceLastExposure: Int.random(in: 0 ... 14),
+      attenuationDurations: [
+        TimeInterval.random(in: 0 ... 1800),
+        TimeInterval.random(in: 0 ... 1800),
+        TimeInterval.random(in: 0 ... 1800)
+      ],
+      maximumRiskScore: Int.random(in: 0 ... 255),
+      exposureInfo: (0 ..< Int.random(in: 1 ... 10)).map { _ in CodableExposureInfo.mock() }
+    )
+  }
+}

--- a/Modules/Extensions/String+Utils.swift
+++ b/Modules/Extensions/String+Utils.swift
@@ -32,4 +32,11 @@ public extension String {
       .hash(data: Data(self.utf8))
       .hexString
   }
+
+  /// Returns a string of random hexadecimal digits with the given `size`
+  static func random(size: Int) -> Self {
+    let requiredBytesOfRandomness = size / 2 + 1
+    let randomData = Data.randomData(with: requiredBytesOfRandomness)
+    return String(randomData.hexString.prefix(size))
+  }
 }

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -37,8 +37,8 @@ public struct Configuration: Codable {
     case dummyIngestionMeanStochasticDelay = "dummy_teks_average_opportunity_waiting_time"
     case dummyIngestionWindowDuration = "dummy_teks_window_duration"
     case dummyIngestionAverageStartUpDelay = "dummy_teks_average_start_waiting_time"
-    case dataUploadMaxSummaryCount = "dataUploadMaxSummaryCount"
-    case dataUploadMaxExposureInfoCount = "dataUploadMaxExposureInfoCount"
+    case dataUploadMaxSummaryCount
+    case dataUploadMaxExposureInfoCount
     case ingestionRequestTargetSize = "teksPacketSize"
   }
 

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -37,6 +37,9 @@ public struct Configuration: Codable {
     case dummyIngestionMeanStochasticDelay = "dummy_teks_average_opportunity_waiting_time"
     case dummyIngestionWindowDuration = "dummy_teks_window_duration"
     case dummyIngestionAverageStartUpDelay = "dummy_teks_average_start_waiting_time"
+    case dataUploadMaxSummaryCount = "dataUploadMaxSummaryCount"
+    case dataUploadMaxExposureInfoCount = "dataUploadMaxExposureInfoCount"
+    case ingestionRequestTargetSize = "teksPacketSize"
   }
 
   /// This is used to enforce a minimum version of the app.
@@ -114,6 +117,15 @@ public struct Configuration: Codable {
   /// Average wait time (in seconds) from the start of a foreground session before starting a simulated dummy ingestion sequence.
   public let dummyIngestionAverageStartUpDelay: Double
 
+  /// The maximum number of Exposure Detection Summary in a DataUpload
+  public let dataUploadMaxSummaryCount: Int
+
+  /// The maximum number of Exposure Info to include in a DataUpload
+  public let dataUploadMaxExposureInfoCount: Int
+
+  /// The target size, in byte, of each ingestion request
+  public let ingestionRequestTargetSize: Int
+
   /// The FAQ url for the given language. it returns english version if the given
   /// language is not available.
   /// Note that the method may still fail in case of missing english version
@@ -148,7 +160,10 @@ public struct Configuration: Codable {
     dummyIngestionRequestProbabilities: [Double] = [0.95, 0.1],
     dummyIngestionMeanStochasticDelay: Double = 864_000,
     dummyIngestionWindowDuration: Double = 86400,
-    dummyIngestionAverageStartUpDelay: Double = 10
+    dummyIngestionAverageStartUpDelay: Double = 10,
+    dataUploadMaxSummaryCount: Int = 84,
+    dataUploadMaxExposureInfoCount: Int = 600,
+    ingestionRequestTargetSize: Int = 110_000
   ) {
     self.minimumBuildVersion = minimumBuildVersion
     self.serviceNotActiveNotificationPeriod = serviceNotActiveNotificationPeriod
@@ -170,6 +185,9 @@ public struct Configuration: Codable {
     self.dummyIngestionMeanStochasticDelay = dummyIngestionMeanStochasticDelay
     self.dummyIngestionWindowDuration = dummyIngestionWindowDuration
     self.dummyIngestionAverageStartUpDelay = dummyIngestionAverageStartUpDelay
+    self.dataUploadMaxSummaryCount = dataUploadMaxSummaryCount
+    self.dataUploadMaxExposureInfoCount = dataUploadMaxExposureInfoCount
+    self.ingestionRequestTargetSize = ingestionRequestTargetSize
   }
 
   // swiftlint:enable force_unwrapping

--- a/Modules/Networking/Core/FixedSizeJSONRequest.swift
+++ b/Modules/Networking/Core/FixedSizeJSONRequest.swift
@@ -1,0 +1,149 @@
+// FixedSizeJSONRequest.swift
+// Copyright (C) 2020 Presidenza del Consiglio dei Ministri.
+// Please refer to the AUTHORS file for more information.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import Alamofire
+import Extensions
+import Foundation
+
+/// An HTTP Requests with a JSON-represented body.
+/// The body has an additional `padding` field that is a random String, the length of which makes it possible for the whole
+/// request (including headers, method, and URL) to have a fixed `targetSize`.
+/// -seeAlso: https://github.com/immuni-app/immuni-documentation/blob/master/Traffic%20Analysis%20Mitigation.md
+public protocol FixedSizeJSONRequest: JSONRequest {
+  var targetSize: Int { get }
+}
+
+public extension FixedSizeJSONRequest {
+  var parametersEncoder: ParameterEncoding {
+    return PaddedJSONEncoding(targetSize: self.targetSize)
+  }
+}
+
+/// A parameter encoding strategy that:
+/// - Adds an additional padding parameter so that the total bytes of the request's url, method, headers and body corresponds to
+///   the given `targetSize`
+/// - Encodes the resulting body in JSON format
+///
+/// *Note*: this assumes that the communication with the server uses the HTTP/1.1 protocol. Unfortunately there seems to be no
+/// way for the client to enforce this, as it's completely handled by iOS.
+/// If for some reasons the communication is upgraded to HTTP2 (and this happens automatically if the server allows it), then the
+/// headers are compressed with HPACK (https://www.rfc-editor.org/rfc/rfc7541.html) and this makes it impossible to ensure
+/// a consistent size among the resulting requests being sent on the wire.
+struct PaddedJSONEncoding: ParameterEncoding {
+  /// The name of the parameter used for padding
+  private static var paddingParameterName: String { "padding" }
+
+  /// The additional overhead caused by adding a field with the given `paddingParameterName`
+  private static var paddingParameterOverhead: Int { "\"\(Self.paddingParameterName)\":\"\"".utf8.count }
+
+  /// The target size that this `ParameterEncoding` must guarantee
+  var targetSize: Int
+
+  /// Given a dictionary of parameters and a given target size, adds an additional `padding` parameter large enough so it adds
+  /// exactly `size` bytes to the JSON representation of the given `parameters`.
+  private static func addPadding(to parameters: [String: Any], size: Int) throws -> [String: Any] {
+    var paddedParameters = parameters
+    let paddingOverhead = parameters.isEmpty
+      ? Self.paddingParameterOverhead
+      : Self.paddingParameterOverhead + 1 // accounts for the additional "," character
+
+    let paddingSize = size - paddingOverhead
+
+    guard paddingSize >= 0 else {
+      /// There is no way of fitting an additional parameter
+      throw Error.paddingOverflow
+    }
+
+    if paddingSize > 0 {
+      paddedParameters[Self.paddingParameterName] = String.random(size: paddingSize)
+    }
+    return paddedParameters
+  }
+
+  /// Note that compared to the implementation of `JSONEncoding` provider by Alamofire, this encoder purposefully avoids adding
+  /// the `Content-Type` header, which then must be explicitly added to the request on the application layer.
+  func encode(_ urlRequest: URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
+    var urlRequest = try urlRequest.asURLRequest()
+
+    let urlSize = urlRequest.url?.byteCount ?? 0
+    let methodSize = urlRequest.method?.byteCount ?? 0
+    let headersSize = urlRequest.headers.map { $0.byteCount }.reduce(0, +)
+
+    let originalParameters = parameters ?? [:]
+    let originalParametersSize = originalParameters.httpRepresentation.byteCount
+
+    let originalRequestSize = urlSize + methodSize + headersSize + originalParametersSize
+
+    let totalPaddingSize = self.targetSize - originalRequestSize
+    let paddedParameters = try Self.addPadding(to: originalParameters, size: totalPaddingSize)
+
+    let data = try JSONSerialization.data(withJSONObject: paddedParameters)
+    urlRequest.httpBody = data
+
+    return urlRequest
+  }
+
+  enum Error: Swift.Error {
+    /// The request is already too big.
+    case paddingOverflow
+  }
+}
+
+// MARK: - HTTPRepresentable
+
+/// A protocol that describes something that can be represented with a given String in a raw HTTP/1.1 request
+protocol HTTPRepresentable {
+  /// The raw representation of the object when encoded in an HTTP/1.1 request
+  var httpRepresentation: String { get }
+}
+
+extension HTTPRepresentable {
+  /// The size in bytes of the `httpRepresentation` for this object
+  var byteCount: Int {
+    return self.httpRepresentation.utf8.count
+  }
+}
+
+extension Parameters {
+  var httpRepresentation: String {
+    let data = (try? JSONSerialization.data(withJSONObject: self)) ?? Data()
+    return String(data: data, encoding: .utf8) ?? ""
+  }
+}
+
+extension String: HTTPRepresentable {
+  var httpRepresentation: String {
+    return self
+  }
+}
+
+extension HTTPMethod: HTTPRepresentable {
+  var httpRepresentation: String {
+    return self.rawValue.uppercased()
+  }
+}
+
+extension URL: HTTPRepresentable {
+  var httpRepresentation: String {
+    return self.absoluteString
+  }
+}
+
+extension HTTPHeader: HTTPRepresentable {
+  var httpRepresentation: String {
+    /// This follows the RFC2616 specification for HTTP Headers in HTTP/1.1
+    /// https://tools.ietf.org/html/rfc2616#section-4.2
+    return "\(self.name): \(self.value)\r\n"
+  }
+}

--- a/Modules/Networking/Core/NetworkManager.swift
+++ b/Modules/Networking/Core/NetworkManager.swift
@@ -18,9 +18,8 @@ import Hydra
 import Models
 
 /// The NetworkManager is the executor of the requests.
-/// It is important to note that the NetworkManager should not contain any additional
-/// information related to the final request that is performed. An instance of HTTPRequest should contain all
-/// the information about a network call
+/// It is important to note that the NetworkManager should not contain any additional information related to the final request
+/// that is performed. An instance of HTTPRequest should contain all the information about a network call.
 public class NetworkManager {
   private var dependencies: Dependencies?
 
@@ -30,7 +29,7 @@ public class NetworkManager {
     self.dependencies = dependencies
   }
 
-  /// Performs the request
+  /// Performs a request
   ///
   /// - parameter request:           the request to perform
   /// - parameter queue:             the queue in which the completion will be invoked. By default Alamofire uses the main thread
@@ -41,7 +40,11 @@ public class NetworkManager {
   ) -> Promise<R.ResponseSerializer.SerializedObject> {
     return self.unwrappedDependencies.requestExecutor.execute(request, queue)
   }
+}
 
+// MARK: - App Configuration Service requests
+
+extension NetworkManager {
   /// Returns the most updated configuration for an app with the given `buildNumber`
   public func getConfiguration(for buildNumber: Int) -> Promise<Configuration> {
     return self.request(ConfigurationRequest(buildNumber: buildNumber))
@@ -53,7 +56,11 @@ public class NetworkManager {
   public func getFAQ(baseURL: URL, path: String) -> Promise<[FAQ]> {
     return self.request(FAQRequest(baseURL: baseURL, path: path)).then { $0.faqs }
   }
+}
 
+// MARK: - Reporting Service requests
+
+extension NetworkManager {
   /// Returns the current manifest for the chunk of TEKs exposed by the backend
   public func getKeysIndex() -> Promise<KeysIndex> {
     return self.request(KeysIndexRequest())
@@ -68,7 +75,11 @@ public class NetworkManager {
 
     return all(requestPromises)
   }
+}
 
+// MARK: - Ingestion service requests
+
+extension NetworkManager {
   /// Validates a given `OTP` with the backend
   public func validateOTP(_ otp: OTP) -> Promise<Void> {
     return self.request(OTPValidationRequest(otp: otp, now: self.unwrappedDependencies.now)).safeVoid
@@ -79,12 +90,18 @@ public class NetworkManager {
   public func uploadData(body: DataUploadRequest.Body, otp: OTP) -> Promise<Void> {
     return self.request(DataUploadRequest(body: body, otp: otp, now: self.unwrappedDependencies.now)).safeVoid
   }
+}
 
+// MARK: - Analytics Service requests
+
+extension NetworkManager {
   /// Sends a request to the Analytics server, following a cycle of Exposure Detection.
   public func sendAnalytics(body: AnalyticsRequest.Body, isDummy: Bool) -> Promise<Void> {
     return self.request(AnalyticsRequest(body: body, isDummy: isDummy)).safeVoid
   }
 }
+
+// MARK: - Supporting types
 
 public extension NetworkManager {
   private var unwrappedDependencies: Dependencies {

--- a/Modules/Networking/Core/NetworkManager.swift
+++ b/Modules/Networking/Core/NetworkManager.swift
@@ -81,14 +81,29 @@ extension NetworkManager {
 
 extension NetworkManager {
   /// Validates a given `OTP` with the backend
-  public func validateOTP(_ otp: OTP) -> Promise<Void> {
-    return self.request(OTPValidationRequest(otp: otp, now: self.unwrappedDependencies.now)).safeVoid
+  public func validateOTP(_ otp: OTP, requestSize: Int) -> Promise<Void> {
+    return self
+      .request(OTPValidationRequest(
+        otp: otp,
+        now: self.unwrappedDependencies.now,
+        targetSize: requestSize
+      )).safeVoid
   }
 
   /// Uploads data to the backend as a consequence of a positive COVID diagnosis. The request is authenticated with a previously
   /// validated OTP.
-  public func uploadData(body: DataUploadRequest.Body, otp: OTP) -> Promise<Void> {
-    return self.request(DataUploadRequest(body: body, otp: otp, now: self.unwrappedDependencies.now)).safeVoid
+  public func uploadData(body: DataUploadRequest.Body, otp: OTP, requestSize: Int) -> Promise<Void> {
+    return self.request(DataUploadRequest(
+      body: body,
+      otp: otp,
+      now: self.unwrappedDependencies.now,
+      targetSize: requestSize
+    )).safeVoid
+  }
+
+  /// Sends a dummy request to the backend.
+  public func sendDummyIngestionRequest(requestSize: Int) -> Promise<Void> {
+    return self.request(DummyIngestionRequest(now: self.unwrappedDependencies.now, targetSize: requestSize)).safeVoid
   }
 }
 

--- a/Modules/Networking/Helpers/JSONRequest+EmptyBody.swift
+++ b/Modules/Networking/Helpers/JSONRequest+EmptyBody.swift
@@ -1,0 +1,24 @@
+// JSONRequest+EmptyBody.swift
+// Copyright (C) 2020 Presidenza del Consiglio dei Ministri.
+// Please refer to the AUTHORS file for more information.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import Foundation
+
+/// An convenience empty encodable struct so that a request can conform to `JSONRequest` without having to implement its own
+/// empty struct
+public struct EmptyBody: Encodable {}
+
+/// Default JSONRequest conformance where `BodyModel` is `EmptyBody`
+public extension JSONRequest where BodyModel == EmptyBody {
+  var jsonParameter: EmptyBody { .init() }
+}

--- a/Modules/Networking/Requests/DataUploadRequest.swift
+++ b/Modules/Networking/Requests/DataUploadRequest.swift
@@ -51,7 +51,6 @@ public extension DataUploadRequest {
     public let teks: [CodableTemporaryExposureKey]
     public let province: String
     public let exposureDetectionSummaries: [CodableExposureDetectionSummary]
-    public let padding: String
 
     /// Create a data upload request body with given teks, province and exposureDetectionSummaries.
     /// A padding is added automatically so that both valid both dummy requests will have the same size.
@@ -63,8 +62,6 @@ public extension DataUploadRequest {
       self.teks = teks
       self.province = province
       self.exposureDetectionSummaries = exposureDetectionSummaries
-      #warning("use meaningful padding")
-      self.padding = ""
     }
   }
 }
@@ -74,6 +71,5 @@ public extension DataUploadRequest.Body {
     case teks
     case province
     case exposureDetectionSummaries = "exposure_detection_summaries"
-    case padding
   }
 }

--- a/Modules/Networking/Requests/DataUploadRequest.swift
+++ b/Modules/Networking/Requests/DataUploadRequest.swift
@@ -17,7 +17,7 @@ import Extensions
 import Foundation
 import Models
 
-public struct DataUploadRequest: JSONRequest {
+public struct DataUploadRequest: FixedSizeJSONRequest {
   // swiftlint:disable:next force_unwrapping
   public var baseURL = URL(string: "https://upload.immuni.gov.it")!
   public var path = "/v1/ingestion/upload"
@@ -36,11 +36,13 @@ public struct DataUploadRequest: JSONRequest {
   public let jsonParameter: Body
   public let otp: OTP
   public let now: () -> Date
+  public let targetSize: Int
 
-  init(body: Body, otp: OTP, now: @escaping () -> Date) {
+  public init(body: Body, otp: OTP, now: @escaping () -> Date, targetSize: Int) {
     self.jsonParameter = body
     self.otp = otp
     self.now = now
+    self.targetSize = targetSize
   }
 }
 
@@ -64,19 +66,6 @@ public extension DataUploadRequest {
       #warning("use meaningful padding")
       self.padding = ""
     }
-  }
-}
-
-public extension DataUploadRequest.Body {
-  static func dummy() -> Self {
-    let randomProvince = Province.allCases.randomElement()
-      ?? LibLogger.fatalError("No provinces defined")
-
-    return self.init(
-      teks: [],
-      province: randomProvince.rawValue,
-      exposureDetectionSummaries: []
-    )
   }
 }
 

--- a/Modules/Networking/Requests/DummyIngestionRequest.swift
+++ b/Modules/Networking/Requests/DummyIngestionRequest.swift
@@ -1,0 +1,47 @@
+// DummyIngestionRequest.swift
+// Copyright (C) 2020 Presidenza del Consiglio dei Ministri.
+// Please refer to the AUTHORS file for more information.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import Alamofire
+import Extensions
+import Foundation
+import Models
+
+public struct DummyIngestionRequest: FixedSizeJSONRequest {
+  public typealias BodyModel = EmptyBody
+
+  // swiftlint:disable:next force_unwrapping
+  public var baseURL = URL(string: "https://upload.immuni.gov.it")!
+
+  // It does not matter which endpoint is used.
+  public var path = "/v1/ingestion/upload"
+  public var method: HTTPMethod = .post
+  public var cachePolicy: NSURLRequest.CachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+
+  public var headers: [HTTPHeader] {
+    return HTTPHeader.defaultImmuniHeaders + [
+      .authorization(bearerToken: OTP().rawValue.sha256),
+      .contentType("application/json; charset=UTF-8"),
+      .dummyData(true),
+      .clientClock(Date(timeIntervalSince1970: 0))
+    ]
+  }
+
+  public let now: () -> Date
+  public var targetSize: Int
+
+  public init(now: @escaping () -> Date, targetSize: Int) {
+    self.now = now
+    self.targetSize = targetSize
+  }
+}

--- a/Modules/Networking/Requests/OTPValidationRequest.swift
+++ b/Modules/Networking/Requests/OTPValidationRequest.swift
@@ -46,10 +46,3 @@ public struct OTPValidationRequest: FixedSizeJSONRequest {
     self.targetSize = targetSize
   }
 }
-
-public extension OTPValidationRequest {
-  struct Body: Encodable {
-    #warning("use meaningful padding")
-    let padding: String = ""
-  }
-}

--- a/Modules/Networking/Requests/OTPValidationRequest.swift
+++ b/Modules/Networking/Requests/OTPValidationRequest.swift
@@ -17,7 +17,9 @@ import Extensions
 import Foundation
 import Models
 
-public struct OTPValidationRequest: JSONRequest {
+public struct OTPValidationRequest: FixedSizeJSONRequest {
+  public typealias BodyModel = EmptyBody
+
   // swiftlint:disable:next force_unwrapping
   public var baseURL = URL(string: "https://upload.immuni.gov.it")!
 
@@ -35,8 +37,14 @@ public struct OTPValidationRequest: JSONRequest {
   }
 
   public let otp: OTP
-  public let jsonParameter = Body()
-  let now: () -> Date
+  public let now: () -> Date
+  public var targetSize: Int
+
+  public init(otp: OTP, now: @escaping () -> Date, targetSize: Int) {
+    self.otp = otp
+    self.now = now
+    self.targetSize = targetSize
+  }
 }
 
 public extension OTPValidationRequest {


### PR DESCRIPTION
*Note*: Merge after #57 

## Description
This PR implements the necessary logic to ensure all Ingestion requests have the same apparent size (when considering URL + Method + Headers + Body).
See [the technical document]https://github.com/immuni-app/immuni-documentation/blob/master/Traffic%20Analysis%20Mitigation.md) for more information.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
