### PR TITLE
ci: disable tooling for production builds only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,7 @@ commands:
               export DISTRIBUTION_METHOD="development"
               export SIGNING_PROFILE="development"
             else
+              echo "export EXCLUDE_DEV_TOOLING='1'" >> $BASH_ENV
               export BUILD_CONFIGURATION="Release"
               export DISTRIBUTION_METHOD="app-store"
               export SIGNING_PROFILE="appstore"
@@ -223,7 +224,7 @@ commands:
             echo "export APP_VERSION=$APP_VERSION" >> $BASH_ENV
       - run:
           name: "[xcode_setup] Configure Xcode project"
-          command: CI_MODE=1 EXCLUDE_DEV_TOOLING=1 make immuni
+          command: CI_MODE=1 make immuni
       - run:
           name: "[xcode_setup] Increment the build number"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ commands:
             - 1-pods-
       - run:
           name: "[cocoapods] Install pods"
-          command: INCLUDE_DEV_TOOLING=TRUE pod install
+          command: pod install
       - save_cache:
           name: "[cocoapods] Save the cache"
           key: 1-pods-{{ checksum "podfile_checksum" }}


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR makes so that the DEV Tools are not included in CI production builds, but are included in CI development builds.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [ ] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

