### PR TITLE
feat(uitests): add support for iOS dynamic type settings in UITests

### DIFF
--- a/UITests/run.py
+++ b/UITests/run.py
@@ -109,7 +109,7 @@ for device in devices:
         
 		# boot the simulator
 		print("Boot the {} simulator".format(device))
-		subprocess.call(["xcrun", "simctl", "boot", simulator_uuid])
+		subprocess.call(["xcrun", "simctl", "boot", device])
 	else:
 		print("Unable to set font size on the {} simulator. This happen if it's the first time you boot it, try it again.".format(device))
 		subprocess.call(["xcrun", "simctl", "boot", device])

--- a/UITests/run.py
+++ b/UITests/run.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import os
 import datetime
+import plistlib
 
 """
 This script will help you running uitests in multiple languages on multiple devices
@@ -15,17 +16,18 @@ To run this script, you must pass some parameters
 - the schema to test
 - whether the app needs to be rebuilt on the simulators
 - the number of simulators on which run the test, if 0 the default will be used
+- the font size of the device, choose between: XS, S, M, L, XL, XXL, XXXL, BigM, BigL, BigXL, BigXXL, BigXXXL
 - a list, space-separated of languages to test
 
 E.g.:
-python UITests/run.py ct-app Immuni.xcworkspace Immuni true 3 it en
+python UITests/run.py ct-app Immuni.xcworkspace Immuni true 3 XL it en
 """
 
-if sys.argv[1] in ["-h", "--h", "--help", "-help"]:
+if len(sys.argv) > 0 and sys.argv[1] in ["-h", "--h", "--help", "-help"]:
 	print(usage)
 	quit()
 
-if len(sys.argv) < 6:
+if len(sys.argv) < 8:
 	print(usage)
 	quit()
 
@@ -46,10 +48,32 @@ bundleId = sys.argv[1]
 workspace = sys.argv[2]
 scheme = sys.argv[3]
 forceReinstall = sys.argv[4]
-max_simulators = int(sys.argv[5]) 
+max_simulators = int(sys.argv[5])
+font_size_arg = sys.argv[6]
 languages = []
 
-for i in range(6, len(sys.argv)):
+available_font_sizes = {
+	'XS'     : 'UICTContentSizeCategoryXS',
+	'S'      : 'UICTContentSizeCategoryS',
+	'M'      : 'UICTContentSizeCategoryM',
+	'L'      : 'UICTContentSizeCategoryL',
+	'XL'     : 'UICTContentSizeCategoryXL',
+	'XXL'    : 'UICTContentSizeCategoryXXL',
+	'XXXL'   : 'UICTContentSizeCategoryXXXL',
+	'BigM'   : 'UICTContentSizeCategoryAccessibilityM',
+	'BigL'   : 'UICTContentSizeCategoryAccessibilityL',
+	'BigXL'  : 'UICTContentSizeCategoryAccessibilityXL',
+	'BigXXL' : 'UICTContentSizeCategoryAccessibilityXXL',
+	'BigXXXL': 'UICTContentSizeCategoryAccessibilityXXXL'
+}
+
+if font_size_arg not in available_font_sizes:
+	print('Selected font size {} is not a valid size, please choose between: XS, S, M, L, XL, XXL, XXXL, BigM, BigL, BigXL, BigXXL, BigXXXL.'.format(font_size))
+	quit()
+
+font_size = available_font_sizes[font_size_arg]
+
+for i in range(7, len(sys.argv)):
 	languages.append(sys.argv[i])
 
 test_without_building_arg = 'test-without-building'
@@ -61,8 +85,37 @@ scheme_arg = '-scheme'
 destination_arg = '-destination'
 
 for device in devices:
+	# get the simulator's uuid
+	list = subprocess.Popen('xcrun simctl list devices 13.5'.split(), stdout=subprocess.PIPE)
+	device_grep = subprocess.Popen(['grep', '{} ('.format(device)], stdin=list.stdout, stdout=subprocess.PIPE)
+	list.stdout.close()
+	uuid_grep = subprocess.Popen('grep -E -o -i ([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})'.split(), stdin=device_grep.stdout, stdout=subprocess.PIPE)
+	device_grep.stdout.close()
+	simulator_uuid = uuid_grep.communicate()[0].decode().strip()
+
+	simulator_fontSize_preferences_file = '{}/Library/Developer/CoreSimulator/Devices/{}/data/Library/Preferences/com.apple.UIKit.plist'.format(os.path.expanduser("~"), simulator_uuid)
+	if os.path.exists(simulator_fontSize_preferences_file):
+		# shutdown the simulator in case it is running
+		print("Shutdown the {} simulator in case it is running".format(device))
+		subprocess.call(["xcrun", "simctl", "shutdown", simulator_uuid])
+        
+		# set the simulator's font size
+		print("Set the {} simulator\'s font size to {}".format(device, font_size))
+		simulator_largerText_preferences_file = '{}/Library/Developer/CoreSimulator/Devices/{}/data/Library/Preferences/com.apple.preferences-framework.plist'.format(os.path.expanduser("~"), simulator_uuid)
+		plistlib.writePlist({'largeTextUsesExtendedRange': True}, simulator_largerText_preferences_file) # enable larger text
+
+		subprocess.call(['plutil', '-replace', 'UIPreferredContentSizeCategoryName',
+		'-string', font_size, simulator_fontSize_preferences_file]) # set the size
+        
+		# boot the simulator
+		print("Boot the {} simulator".format(device))
+		subprocess.call(["xcrun", "simctl", "boot", simulator_uuid])
+	else:
+		print("Unable to set font size on the {} simulator. This happen if it's the first time you boot it, try it again.".format(device))
+		subprocess.call(["xcrun", "simctl", "boot", device])
+		quit()
+
 	device_args += [destination_arg, "name={}".format(device)]
-	subprocess.call(["xcrun", "simctl", "boot", device])
 
 if forceReinstall == "true":
 	# uninstall app on each simulator
@@ -73,17 +126,17 @@ if forceReinstall == "true":
 	subprocess.call([
 		command,
 		build_for_testing_arg,
-		workspace_arg, workspace, 
+		workspace_arg, workspace,
 		scheme_arg, scheme
 	] + device_args)
 
 # perform UI tests
 for lang in languages:
 	language_arg = '-testLanguage'
-	args = [command, 
-		test_without_building_arg, 
+	args = [command,
+        test_without_building_arg,
 		max_concurrent_simulator_arg, str(max_simulators),
-		workspace_arg, workspace, 
+		workspace_arg, workspace,
 		scheme_arg, scheme,
 		language_arg, lang,
 		'-only-testing:Immuni UITests'] + device_args

--- a/UITests/run.py
+++ b/UITests/run.py
@@ -23,7 +23,7 @@ E.g.:
 python UITests/run.py ct-app Immuni.xcworkspace Immuni true 3 XL it en
 """
 
-if len(sys.argv) > 0 and sys.argv[1] in ["-h", "--h", "--help", "-help"]:
+if len(sys.argv) > 1 and sys.argv[1] in ["-h", "--h", "--help", "-help"]:
 	print(usage)
 	quit()
 
@@ -97,8 +97,8 @@ for device in devices:
 	if os.path.exists(simulator_fontSize_preferences_file):
 		# shutdown the simulator in case it is running
 		print("Shutdown the {} simulator in case it is running".format(device))
-		subprocess.call(["xcrun", "simctl", "shutdown", simulator_uuid])
-        
+		subprocess.call(["xcrun", "simctl", "shutdown", device], stderr=open(os.devnull))
+
 		# set the simulator's font size
 		print("Set the {} simulator\'s font size to {}".format(device, font_size))
 		simulator_largerText_preferences_file = '{}/Library/Developer/CoreSimulator/Devices/{}/data/Library/Preferences/com.apple.preferences-framework.plist'.format(os.path.expanduser("~"), simulator_uuid)
@@ -106,7 +106,7 @@ for device in devices:
 
 		subprocess.call(['plutil', '-replace', 'UIPreferredContentSizeCategoryName',
 		'-string', font_size, simulator_fontSize_preferences_file]) # set the size
-        
+
 		# boot the simulator
 		print("Boot the {} simulator".format(device))
 		subprocess.call(["xcrun", "simctl", "boot", device])
@@ -140,7 +140,7 @@ for lang in languages:
 		scheme_arg, scheme,
 		language_arg, lang,
 		'-only-testing:Immuni UITests'] + device_args
-	
+
 	print("\n\n Calling xcodebuild for language "+lang)
 	subprocess.call(args)
 


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description
The solution I'm proposing is a little hacky, but it should help running UITests with different font sizes without manually change the setting of the simulators.
It is based on the undocumented parameters I've found [here](https://github.com/fastlane/fastlane/issues/2490#issuecomment-193498984).

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

<!-- Please insert the issue numbers after the # symbol -->

- Fixes #40
