### PR TITLE
fix: align configuration properties and defaults

### DIFF
--- a/App/Dependencies/ExposureDetection/ImmuniExposureDetectionExecutor.swift
+++ b/App/Dependencies/ExposureDetection/ImmuniExposureDetectionExecutor.swift
@@ -175,6 +175,7 @@ private extension Configuration.ExposureDetectionConfiguration {
     configuration.transmissionRiskBucketScores = self.transmissionRiskBucketScores
     configuration.transmissionRiskWeight = self.transmissionRiskWeight
     configuration.minimumRiskScore = self.minimumRiskScore
+    configuration.attenuationThresholds = self.attenuationThresholds
     return configuration
   }
 }

--- a/AppTests/App/Logic/ExposureDetectionLogicTests.swift
+++ b/AppTests/App/Logic/ExposureDetectionLogicTests.swift
@@ -187,7 +187,6 @@ final class ExposureDetectionLogicTests: XCTestCase {
     }
   }
 
-
   func testUpdateUserStatusIfNecessaryIsBeingCalled() throws {
     let outcome: ExposureDetectionOutcome = .fullDetection(Date(), .noMatch, [], 0, 5)
     let state = AppState()

--- a/AppTests/ImmuniExposureNotification/ExposureNotificationMocks.swift
+++ b/AppTests/ImmuniExposureNotification/ExposureNotificationMocks.swift
@@ -109,6 +109,7 @@ struct MockExposureDetectionConfiguration: ExposureDetectionConfiguration, Equat
   var transmissionRiskBucketScores: [RiskScore]
   var transmissionRiskWeight: Double
   var minimumRiskScore: RiskScore
+  var attenuationThresholds: [Int]
 
   static func mock() -> Self {
     return MockExposureDetectionConfiguration(
@@ -120,7 +121,8 @@ struct MockExposureDetectionConfiguration: ExposureDetectionConfiguration, Equat
       durationWeight: 1,
       transmissionRiskBucketScores: [1, 2, 3, 4, 5, 6, 7, 8],
       transmissionRiskWeight: 1,
-      minimumRiskScore: 0
+      minimumRiskScore: 0,
+      attenuationThresholds: [50, 70]
     )
   }
 }

--- a/Modules/ImmuniExposureNotification/ENConformances/ENTypes+Bridging.swift
+++ b/Modules/ImmuniExposureNotification/ENConformances/ENTypes+Bridging.swift
@@ -137,11 +137,12 @@ extension ENExposureConfiguration: ExposureDetectionConfiguration {
 
   public var attenuationThresholds: [Int] {
     get {
-      self.metadata?[Self.metadataAttenuationDurationThresholdsKey] as? [Int] ?? []
+      let value = self.metadata?[Self.metadataAttenuationDurationThresholdsKey] as? [NSNumber] ?? []
+      return value.map { $0.intValue }
     }
     set {
       var metadata = self.metadata ?? [:]
-      metadata[Self.metadataAttenuationDurationThresholdsKey] = newValue
+      metadata[Self.metadataAttenuationDurationThresholdsKey] = newValue.map { NSNumber(value: $0) }
       self.metadata = metadata
     }
   }

--- a/Modules/ImmuniExposureNotification/ENConformances/ENTypes+Bridging.swift
+++ b/Modules/ImmuniExposureNotification/ENConformances/ENTypes+Bridging.swift
@@ -132,6 +132,20 @@ extension ExposureNotificationStatus {
 
 @available(iOS 13.5, *)
 extension ENExposureConfiguration: ExposureDetectionConfiguration {
+  /// The key inside the metadata for the threshold for attenuation buckets
+  static var metadataAttenuationDurationThresholdsKey: String { "attenuationDurationThresholds" }
+
+  public var attenuationThresholds: [Int] {
+    get {
+      self.metadata?[Self.metadataAttenuationDurationThresholdsKey] as? [Int] ?? []
+    }
+    set {
+      var metadata = self.metadata ?? [:]
+      metadata[Self.metadataAttenuationDurationThresholdsKey] = newValue
+      self.metadata = metadata
+    }
+  }
+
   public var attenuationBucketScores: [RiskScore] {
     get {
       return self.attenuationLevelValues.map { $0.uint8Value }

--- a/Modules/ImmuniExposureNotification/ExposureNotification+Models.swift
+++ b/Modules/ImmuniExposureNotification/ExposureNotification+Models.swift
@@ -156,6 +156,9 @@ public protocol ExposureDetectionConfiguration {
 
   /// The user’s minimum risk score.
   var minimumRiskScore: RiskScore { get set }
+
+  /// The thresholds of dBm that dictates how attenuations are divided into buckets in `ExposureInfo.attenuationDurations`
+  var attenuationThresholds: [Int] { get set }
 }
 
 /// The metadata associated to a single Exposure event.

--- a/Modules/ImmuniExposureNotification/FallbackStubs/ExposureNotificationProviderStub.swift
+++ b/Modules/ImmuniExposureNotification/FallbackStubs/ExposureNotificationProviderStub.swift
@@ -63,6 +63,7 @@ public struct ExposureDetectionConfigurationStub: ExposureDetectionConfiguration
   public var transmissionRiskBucketScores: [RiskScore]
   public var transmissionRiskWeight: Double
   public var minimumRiskScore: RiskScore
+  public var attenuationThresholds: [Int]
 
   public init(
     attenuationBucketScores: [RiskScore] = [1, 2, 3, 4, 5, 6, 7, 8],
@@ -73,7 +74,8 @@ public struct ExposureDetectionConfigurationStub: ExposureDetectionConfiguration
     durationWeight: Double = 1,
     transmissionRiskBucketScores: [RiskScore] = [1, 2, 3, 4, 5, 6, 7, 8],
     transmissionRiskWeight: Double = 1,
-    minimumRiskScore: RiskScore = 1
+    minimumRiskScore: RiskScore = 1,
+    attenuationThresholds: [Int] = [50, 70]
   ) {
     self.attenuationBucketScores = attenuationBucketScores
     self.attenuationWeight = attenuationWeight
@@ -84,5 +86,6 @@ public struct ExposureDetectionConfigurationStub: ExposureDetectionConfiguration
     self.transmissionRiskBucketScores = transmissionRiskBucketScores
     self.transmissionRiskWeight = transmissionRiskWeight
     self.minimumRiskScore = minimumRiskScore
+    self.attenuationThresholds = attenuationThresholds
   }
 }

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -37,9 +37,9 @@ public struct Configuration: Codable {
     case dummyIngestionMeanStochasticDelay = "dummy_teks_average_opportunity_waiting_time"
     case dummyIngestionWindowDuration = "dummy_teks_window_duration"
     case dummyIngestionAverageStartUpDelay = "dummy_teks_average_start_waiting_time"
-    case dataUploadMaxSummaryCount
-    case dataUploadMaxExposureInfoCount
-    case ingestionRequestTargetSize = "teksPacketSize"
+    case dataUploadMaxSummaryCount = "teks_max_summary_count"
+    case dataUploadMaxExposureInfoCount = "teks_max_info_count"
+    case ingestionRequestTargetSize = "teks_packet_size"
   }
 
   /// This is used to enforce a minimum version of the app.

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -137,12 +137,12 @@ public struct Configuration: Codable {
   #warning("Tune default parameters")
   // swiftlint:disable force_unwrapping
   public init(
-    minimumBuildVersion: Int = 0,
+    minimumBuildVersion: Int = 1,
     serviceNotActiveNotificationPeriod: TimeInterval = 86400,
     osForceUpdateNotificationPeriod: TimeInterval = 86400,
     requiredUpdateNotificationPeriod: TimeInterval = 86400,
     riskReminderNotificationPeriod: TimeInterval = 86400,
-    exposureDetectionPeriod: TimeInterval = 7200,
+    exposureDetectionPeriod: TimeInterval = 14400,
     exposureConfiguration: ExposureDetectionConfiguration = .init(),
     exposureInfoMinimumRiskScore: Int = 1,
     maximumExposureDetectionWaitingTime: TimeInterval = 86400,
@@ -154,7 +154,7 @@ public struct Configuration: Codable {
       UserLanguage.german.rawValue: URL(string: "http://www.example.com")!
     ],
     operationalInfoWithExposureSamplingRate: Double = 1,
-    operationalInfoWithoutExposureSamplingRate: Double = 1,
+    operationalInfoWithoutExposureSamplingRate: Double = 0.1,
     dummyAnalyticsWaitingTime: Double = 2_592_000,
     dummyIngestionAverageRequestWaitingTime: Double = 10,
     dummyIngestionRequestProbabilities: [Double] = [0.95, 0.1],

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -242,14 +242,14 @@ public extension Configuration {
     /// Public initializer to allow testing
     #warning("Tune default parameters")
     public init(
-      attenuationBucketScores: [UInt8] = [1, 1, 2, 3, 4, 5, 6, 7],
       attenuationThresholds: [Int] = [50, 70],
+      attenuationBucketScores: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8],
       attenuationWeight: Double = 1,
-      daysSinceLastExposureBucketScores: [UInt8] = [1, 1, 2, 3, 4, 5, 6, 7],
+      daysSinceLastExposureBucketScores: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8],
       daysSinceLastExposureWeight: Double = 1,
-      durationBucketScores: [UInt8] = [1, 1, 2, 3, 4, 5, 6, 7],
+      durationBucketScores: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8],
       durationWeight: Double = 1,
-      transmissionRiskBucketScores: [UInt8] = [1, 1, 2, 3, 4, 5, 6, 7],
+      transmissionRiskBucketScores: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8],
       transmissionRiskWeight: Double = 1,
       minimumRiskScore: UInt8 = 1
     ) {

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -133,7 +133,6 @@ public struct Configuration: Codable {
     return self.faqURL[language.rawValue] ?? self.faqURL[UserLanguage.english.rawValue]
   }
 
-
   /// Public initializer to allow testing
   #warning("Tune default parameters")
   // swiftlint:disable force_unwrapping

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -197,6 +197,7 @@ public struct Configuration: Codable {
 public extension Configuration {
   struct ExposureDetectionConfiguration: Codable {
     enum CodingKeys: String, CodingKey {
+      case attenuationThresholds = "attenuation_thresholds"
       case attenuationBucketScores = "attenuation_bucket_scores"
       case attenuationWeight = "attenuation_weight"
       case daysSinceLastExposureBucketScores = "days_since_last_exposure_bucket_scores"
@@ -207,6 +208,9 @@ public extension Configuration {
       case transmissionRiskWeight = "transmission_risk_weight"
       case minimumRiskScore = "minimum_risk_score"
     }
+
+    /// The thresholds of dBm that dictates how attenuations are divided into buckets in `ExposureInfo.attenuationDurations`
+    public let attenuationThresholds: [Int]
 
     /// Scores that indicate Bluetooth signal strength.
     public let attenuationBucketScores: [UInt8]
@@ -239,6 +243,7 @@ public extension Configuration {
     #warning("Tune default parameters")
     public init(
       attenuationBucketScores: [UInt8] = [1, 1, 2, 3, 4, 5, 6, 7],
+      attenuationThresholds: [Int] = [50, 70],
       attenuationWeight: Double = 1,
       daysSinceLastExposureBucketScores: [UInt8] = [1, 1, 2, 3, 4, 5, 6, 7],
       daysSinceLastExposureWeight: Double = 1,
@@ -248,6 +253,7 @@ public extension Configuration {
       transmissionRiskWeight: Double = 1,
       minimumRiskScore: UInt8 = 1
     ) {
+      self.attenuationThresholds = attenuationThresholds
       self.attenuationBucketScores = attenuationBucketScores
       self.attenuationWeight = attenuationWeight
       self.daysSinceLastExposureBucketScores = daysSinceLastExposureBucketScores


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description
This PR aligns the configuration properties and defaults to the backend. Moreover, it wires the [attenuationDurationThresholds](https://developer.apple.com/documentation/exposurenotification/enexposureconfiguration/3586322-metadata) of ENExposureConfiguration, although from what I'm seeing it seems that the framework currently discards it and defaults to `[50, 70]`.
## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket: