### PR TITLE
fix: lifecycle management

### DIFF
--- a/App/Application/AppDelegate.swift
+++ b/App/Application/AppDelegate.swift
@@ -154,6 +154,9 @@ extension AppDelegate {
       .onNotification(UIApplication.willEnterForegroundNotification, [
         Logic.Lifecycle.WillEnterForeground.self
       ]),
+      .onNotification(UIApplication.didEnterBackgroundNotification, [
+        Logic.Lifecycle.DidEnterBackground.self
+      ]),
       .onNotification(UIApplication.didBecomeActiveNotification, [
         Logic.Lifecycle.DidBecomeActive.self
       ]),

--- a/App/Logic/LifecycleLogic.swift
+++ b/App/Logic/LifecycleLogic.swift
@@ -140,11 +140,24 @@ extension Logic {
       }
 
       func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
-        // resets the state related to dummy sessions
-        try context.awaitDispatch(Logic.DataUpload.MarkForegroundSessionFinished())
-
         // show sensitive data overlay. Check `SensitiveDataCoverVC` documentation.
         context.dispatch(Logic.Shared.ShowSensitiveDataCoverIfNeeded())
+      }
+    }
+
+    /// Launched when the app entered background
+    struct DidEnterBackground: AppSideEffect, NotificationObserverDispatchable {
+      init() {}
+
+      init?(notification: Notification) {
+        guard notification.name == UIApplication.didEnterBackgroundNotification else {
+          return nil
+        }
+      }
+
+      func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
+        // resets the state related to dummy sessions
+        try context.awaitDispatch(Logic.DataUpload.MarkForegroundSessionFinished())
       }
     }
 

--- a/App/Logic/LifecycleLogic.swift
+++ b/App/Logic/LifecycleLogic.swift
@@ -13,6 +13,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import BackgroundTasks
+import Extensions
 import Foundation
 import Hydra
 import ImmuniExposureNotification
@@ -66,7 +67,7 @@ extension Logic {
           return
         }
 
-        guard context.dependencies.application.applicationState == .active else {
+        guard context.dependencies.application.isForeground else {
           // Background sessions are handled in `HandleExposureDetectionBackgroundTask`
           return
         }
@@ -277,6 +278,16 @@ private extension Logic.Lifecycle {
   struct PassFirstLaunchExecuted: AppStateUpdater {
     func updateState(_ state: inout AppState) {
       state.toggles.isFirstLaunchSetupPerformed = true
+    }
+  }
+}
+
+// MARK: - Helpers
+
+extension UIApplication {
+  var isForeground: Bool {
+    mainThread {
+      self.applicationState == .active
     }
   }
 }

--- a/AppTests/App/Logic/DataUploadLogicTests.swift
+++ b/AppTests/App/Logic/DataUploadLogicTests.swift
@@ -559,13 +559,13 @@ extension DataUploadLogicTests {
     }
   }
 
-  func testForegroundSessionIsMarkedFinishedWhenEnteringForeground() throws {
+  func testForegroundSessionIsMarkedFinishedWhenEnteringBackground() throws {
     let dispatchInterceptor = DispatchInterceptor()
     let dependencies = AppDependencies.mocked(dispatch: dispatchInterceptor.dispatchFunction)
 
     let context = AppSideEffectContext(dependencies: dependencies)
 
-    try Logic.Lifecycle.WillResignActive().sideEffect(context)
+    try Logic.Lifecycle.DidEnterBackground().sideEffect(context)
 
     try XCTAssertContainsType(dispatchInterceptor.dispatchedItems, Logic.DataUpload.MarkForegroundSessionFinished.self)
   }

--- a/AppTests/App/Logic/ExposureDetectionLogicTests.swift
+++ b/AppTests/App/Logic/ExposureDetectionLogicTests.swift
@@ -187,7 +187,6 @@ final class ExposureDetectionLogicTests: XCTestCase {
     }
   }
 
-
   func testUpdateUserStatusIfNecessaryIsBeingCalled() throws {
     let outcome: ExposureDetectionOutcome = .fullDetection(Date(), .noMatch, [], 0, 5)
     let state = AppState()

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -133,7 +133,6 @@ public struct Configuration: Codable {
     return self.faqURL[language.rawValue] ?? self.faqURL[UserLanguage.english.rawValue]
   }
 
-
   /// Public initializer to allow testing
   #warning("Tune default parameters")
   // swiftlint:disable force_unwrapping


### PR DESCRIPTION
## Description
This PR fixes the lifecycle logic to only perform certain actions when OnStart is called in a foreground session.

Also, moves a sideeffect from WillResignActive to DidEnterForeground

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
