### PR TITLE
fix: configuration naming

### DIFF
--- a/App/Logic/SettingsLogic.swift
+++ b/App/Logic/SettingsLogic.swift
@@ -51,7 +51,7 @@ extension Logic.Settings {
     }
   }
 
-  /// Shows a the privacy policy
+  /// Shows a the privacy notice
   struct ShowPrivacyNotice: AppSideEffect {
     func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
       try context.awaitDispatch(Show(Screen.privacy, animated: true))
@@ -64,7 +64,7 @@ extension Logic.Settings {
       let state = context.getState()
 
       guard let privacyNoticeURL = state.configuration.privacyNoticeURL(for: state.environment.userLanguage) else {
-        // server missconfiguration
+        // server misconfiguration
         return
       }
 
@@ -78,7 +78,7 @@ extension Logic.Settings {
       let state = context.getState()
 
       guard let termsOfUseURL = state.configuration.termsOfUseURL(for: state.environment.userLanguage) else {
-        // server missconfiguration
+        // server misconfiguration
         return
       }
 

--- a/App/Logic/SettingsLogic.swift
+++ b/App/Logic/SettingsLogic.swift
@@ -61,16 +61,28 @@ extension Logic.Settings {
   /// Shows a the full privacy policy
   struct ShowFullPrivacyPolicy: AppSideEffect {
     func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
-      let url = context.getState().configuration.privacyPolicyURL
-      try context.awaitDispatch(Show(Screen.web, animated: true, context: WebLS(url: url)))
+      let state = context.getState()
+
+      guard let privacyNoticeURL = state.configuration.privacyNoticeURL(for: state.environment.userLanguage) else {
+        // server missconfiguration
+        return
+      }
+
+      try context.awaitDispatch(Show(Screen.web, animated: true, context: WebLS(url: privacyNoticeURL)))
     }
   }
 
   /// Shows the TOS page
   struct ShowTOS: AppSideEffect {
     func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
-      let url = context.getState().configuration.tosURL
-      try context.awaitDispatch(Show(Screen.web, animated: true, context: WebLS(url: url)))
+      let state = context.getState()
+
+      guard let termsOfUseURL = state.configuration.termsOfUseURL(for: state.environment.userLanguage) else {
+        // server missconfiguration
+        return
+      }
+
+      try context.awaitDispatch(Show(Screen.web, animated: true, context: WebLS(url: termsOfUseURL)))
     }
   }
 

--- a/App/Logic/SettingsLogic.swift
+++ b/App/Logic/SettingsLogic.swift
@@ -52,14 +52,14 @@ extension Logic.Settings {
   }
 
   /// Shows a the privacy policy
-  struct ShowPrivacyPolicy: AppSideEffect {
+  struct ShowPrivacyNotice: AppSideEffect {
     func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
       try context.awaitDispatch(Show(Screen.privacy, animated: true))
     }
   }
 
   /// Shows a the full privacy policy
-  struct ShowFullPrivacyPolicy: AppSideEffect {
+  struct ShowFullPrivacyNotice: AppSideEffect {
     func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
       let state = context.getState()
 
@@ -72,8 +72,8 @@ extension Logic.Settings {
     }
   }
 
-  /// Shows the TOS page
-  struct ShowTOS: AppSideEffect {
+  /// Shows the TOU page
+  struct ShowTOU: AppSideEffect {
     func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
       let state = context.getState()
 

--- a/App/State/FaqState.swift
+++ b/App/State/FaqState.swift
@@ -44,6 +44,12 @@ struct FaqState: Codable {
 
     case .german:
       return FAQ.germanDefaultValues
+
+    case .french:
+      return FAQ.frenchDefaultValues
+
+    case .spanish:
+      return FAQ.spanishDefaultValues
     }
   }
 }

--- a/App/UI/Privacy/Cells/PrivacyCheckboxCell.swift
+++ b/App/UI/Privacy/Cells/PrivacyCheckboxCell.swift
@@ -51,13 +51,13 @@ struct PrivacyCheckboxCellVM: ViewModel, Equatable {
 extension PrivacyCheckboxCellVM {
   enum CellType: Equatable {
     case above14
-    case privacyPolicyRead
+    case privacyNoticeRead
 
     var description: String {
       switch self {
       case .above14:
         return L10n.Privacy.Checkbox.above14
-      case .privacyPolicyRead:
+      case .privacyNoticeRead:
         return L10n.Privacy.Checkbox.privacyPolicyRead
       }
     }

--- a/App/UI/Privacy/Cells/PrivacyTOUCell.swift
+++ b/App/UI/Privacy/Cells/PrivacyTOUCell.swift
@@ -1,4 +1,4 @@
-// PrivacyTOSCell.swift
+// PrivacyTOUCell.swift
 // Copyright (C) 2020 Presidenza del Consiglio dei Ministri.
 // Please refer to the AUTHORS file for more information.
 // This program is free software: you can redistribute it and/or modify

--- a/App/UI/Privacy/Cells/PrivacyTOUCell.swift
+++ b/App/UI/Privacy/Cells/PrivacyTOUCell.swift
@@ -19,7 +19,7 @@ import Katana
 import PinLayout
 import Tempura
 
-struct PrivacyTOSCellVM: ViewModel, Equatable {
+struct PrivacyTOUCellVM: ViewModel, Equatable {
   let content: String
   let tosURL: URL?
 
@@ -28,7 +28,7 @@ struct PrivacyTOSCellVM: ViewModel, Equatable {
   }
 }
 
-final class PrivacyTOSCell: UICollectionViewCell, ModellableView, ReusableView {
+final class PrivacyTOUCell: UICollectionViewCell, ModellableView, ReusableView {
   private static let horizontalPadding: CGFloat = 30.0
 
   var userDidTapURL: CustomInteraction<URL>?
@@ -55,7 +55,7 @@ final class PrivacyTOSCell: UICollectionViewCell, ModellableView, ReusableView {
 
   func style() {}
 
-  func update(oldModel: PrivacyTOSCellVM?) {
+  func update(oldModel: PrivacyTOUCellVM?) {
     guard let model = self.model else {
       return
     }
@@ -85,7 +85,7 @@ final class PrivacyTOSCell: UICollectionViewCell, ModellableView, ReusableView {
   }
 }
 
-extension PrivacyTOSCell: UITextViewDelegate {
+extension PrivacyTOUCell: UITextViewDelegate {
   func textView(
     _ textView: UITextView,
     shouldInteractWith URL: URL,
@@ -100,7 +100,7 @@ extension PrivacyTOSCell: UITextViewDelegate {
   }
 }
 
-private extension PrivacyTOSCell {
+private extension PrivacyTOUCell {
   enum Style {
     static func content(_ textView: UITextView, content: String, url: URL?) {
       textView.isSelectable = true

--- a/App/UI/Privacy/PrivacyVC.swift
+++ b/App/UI/Privacy/PrivacyVC.swift
@@ -34,12 +34,12 @@ final class PrivacyVC: ViewControllerWithLocalState<PrivacyView> {
       self.localState = self.localState.byTogglingAbove14()
     }
 
-    self.rootView.userDidTapReadPrivacyPolicyCheckbox = { [weak self] in
+    self.rootView.userDidTapReadPrivacyNoticeCheckbox = { [weak self] in
       guard let self = self else {
         return
       }
 
-      self.localState = self.localState.byTogglingReadPrivacyPolicy()
+      self.localState = self.localState.byTogglingReadPrivacyNotice()
     }
 
     self.rootView.userDidTapActionButton = { [weak self] in
@@ -66,11 +66,11 @@ final class PrivacyVC: ViewControllerWithLocalState<PrivacyView> {
   }
 
   private func handleSettingsActionButtonTap() {
-    self.store.dispatch(Logic.Settings.ShowFullPrivacyPolicy())
+    self.store.dispatch(Logic.Settings.ShowFullPrivacyNotice())
   }
 
   private func handleOnboardingActionButtonTap() {
-    guard !self.localState.isReadPrivacyPolicyChecked || !self.localState.isAbove14Checked else {
+    guard !self.localState.isReadPrivacyNoticeChecked || !self.localState.isAbove14Checked else {
       self.store.dispatch(Logic.Privacy.UserHasCompletedPrivacyScreen())
       return
     }
@@ -101,26 +101,26 @@ struct PrivacyLS: LocalState {
   /// Whether the above 14 checkbox is checked.
   var isAbove14Checked: Bool
   /// Whether the privacy policy checkbox is checked.
-  var isReadPrivacyPolicyChecked: Bool
+  var isReadPrivacyNoticeChecked: Bool
 
   /// Whether the above 14 checkbox is errored.
   var isAbove14Errored: Bool
   /// Whether the privacy policy checkbox is errored.
-  var isReadPrivacyPolicyErrored: Bool
+  var isReadPrivacyNoticeErrored: Bool
 
   init(kind: Kind) {
     self.kind = kind
     self.isHeaderVisible = false
     self.isAbove14Checked = false
-    self.isReadPrivacyPolicyChecked = false
+    self.isReadPrivacyNoticeChecked = false
     self.isAbove14Errored = false
-    self.isReadPrivacyPolicyErrored = false
+    self.isReadPrivacyNoticeErrored = false
   }
 
   func erroredVersion() -> Self {
     var copy = self
     copy.isAbove14Errored = !copy.isAbove14Checked
-    copy.isReadPrivacyPolicyErrored = !copy.isReadPrivacyPolicyChecked
+    copy.isReadPrivacyNoticeErrored = !copy.isReadPrivacyNoticeChecked
     return copy
   }
 
@@ -131,10 +131,10 @@ struct PrivacyLS: LocalState {
     return copy
   }
 
-  func byTogglingReadPrivacyPolicy() -> Self {
+  func byTogglingReadPrivacyNotice() -> Self {
     var copy = self
-    copy.isReadPrivacyPolicyErrored = false
-    copy.isReadPrivacyPolicyChecked.toggle()
+    copy.isReadPrivacyNoticeErrored = false
+    copy.isReadPrivacyNoticeChecked.toggle()
     return copy
   }
 }

--- a/App/UI/Privacy/PrivacyVM.swift
+++ b/App/UI/Privacy/PrivacyVM.swift
@@ -46,13 +46,15 @@ extension PrivacyVM: ViewModelWithLocalState {
     }
 
     let configuration = state.configuration
+    let touURL = configuration.termsOfUseURL(for: state.environment.userLanguage)
+    let privacyNoticeURL = configuration.privacyNoticeURL(for: state.environment.userLanguage)
 
     switch localState.kind {
     case .onboarding:
       self = Self.onboardingPrivacy(
         isHeaderVisible: localState.isHeaderVisible,
-        tosURL: configuration.tosURL,
-        privacyPolicyURL: configuration.privacyPolicyURL,
+        tosURL: touURL,
+        privacyPolicyURL: privacyNoticeURL,
         isAbove14Checked: localState.isAbove14Checked,
         isAbove14Errored: localState.isAbove14Errored,
         isReadPrivacyPolicyChecked: localState.isReadPrivacyPolicyChecked,

--- a/App/UI/Privacy/PrivacyVM.swift
+++ b/App/UI/Privacy/PrivacyVM.swift
@@ -53,12 +53,12 @@ extension PrivacyVM: ViewModelWithLocalState {
     case .onboarding:
       self = Self.onboardingPrivacy(
         isHeaderVisible: localState.isHeaderVisible,
-        tosURL: touURL,
-        privacyPolicyURL: privacyNoticeURL,
+        touURL: touURL,
+        privacyNoticeURL: privacyNoticeURL,
         isAbove14Checked: localState.isAbove14Checked,
         isAbove14Errored: localState.isAbove14Errored,
-        isReadPrivacyPolicyChecked: localState.isReadPrivacyPolicyChecked,
-        isReadPrivacyPolicyErrored: localState.isReadPrivacyPolicyErrored
+        isReadPrivacyNoticeChecked: localState.isReadPrivacyNoticeChecked,
+        isReadPrivacyNoticeErrored: localState.isReadPrivacyNoticeErrored
       )
 
     case .settings:
@@ -71,12 +71,12 @@ extension PrivacyVM {
   /// Creates a VM for the Onboarding privacy screen
   static func onboardingPrivacy(
     isHeaderVisible: Bool,
-    tosURL: URL?,
-    privacyPolicyURL: URL?,
+    touURL: URL?,
+    privacyNoticeURL: URL?,
     isAbove14Checked: Bool,
     isAbove14Errored: Bool,
-    isReadPrivacyPolicyChecked: Bool,
-    isReadPrivacyPolicyErrored: Bool
+    isReadPrivacyNoticeChecked: Bool,
+    isReadPrivacyNoticeErrored: Bool
   ) -> Self {
     let items: [CellType] = [
       .title(L10n.Privacy.title),
@@ -97,12 +97,12 @@ extension PrivacyVM {
       .spacer(.small),
       .checkbox(type: .above14, isSelected: isAbove14Checked, isErrored: isAbove14Errored, linkedURL: nil),
       .checkbox(
-        type: .privacyPolicyRead,
-        isSelected: isReadPrivacyPolicyChecked,
-        isErrored: isReadPrivacyPolicyErrored,
-        linkedURL: privacyPolicyURL
+        type: .privacyNoticeRead,
+        isSelected: isReadPrivacyNoticeChecked,
+        isErrored: isReadPrivacyNoticeErrored,
+        linkedURL: privacyNoticeURL
       ),
-      .tos(tosURL)
+      .tou(touURL)
     ]
 
     return Self(items: items, isHeaderVisible: isHeaderVisible, buttonTitle: L10n.Privacy.next, headerTitle: L10n.Privacy.title)
@@ -143,7 +143,7 @@ extension PrivacyVM {
     case title(String)
     case checkbox(type: PrivacyCheckboxCellVM.CellType, isSelected: Bool, isErrored: Bool, linkedURL: URL?)
     case spacer(PrivacySpacerCellVM.Size)
-    case tos(URL?)
+    case tou(URL?)
 
     var cellVM: ViewModel {
       switch self {
@@ -159,8 +159,8 @@ extension PrivacyVM {
       case .spacer(let size):
         return PrivacySpacerCellVM(size: size)
 
-      case .tos(let url):
-        return PrivacyTOSCellVM(content: L10n.Privacy.tos, tosURL: url)
+      case .tou(let url):
+        return PrivacyTOUCellVM(content: L10n.Privacy.tos, tosURL: url)
       }
     }
   }

--- a/App/UI/Privacy/PrivacyView.swift
+++ b/App/UI/Privacy/PrivacyView.swift
@@ -28,7 +28,7 @@ final class PrivacyView: UIView, ViewControllerModellableView {
   var userDidTapClose: Interaction?
   var userDidTapActionButton: Interaction?
   var userDidTapAbove14Checkbox: Interaction?
-  var userDidTapReadPrivacyPolicyCheckbox: Interaction?
+  var userDidTapReadPrivacyNoticeCheckbox: Interaction?
   var userDidScroll: CustomInteraction<CGFloat>?
   var userDidTapURL: CustomInteraction<URL>?
 
@@ -43,7 +43,7 @@ final class PrivacyView: UIView, ViewControllerModellableView {
     collection.register(PrivacyTitleCell.self)
     collection.register(PrivacyCheckboxCell.self)
     collection.register(PrivacySpacerCell.self)
-    collection.register(PrivacyTOSCell.self)
+    collection.register(PrivacyTOUCell.self)
 
     return collection
   }()
@@ -229,8 +229,8 @@ extension PrivacyView: UICollectionViewDataSource {
     case .spacer:
       return self.dequeue(PrivacySpacerCell.self, for: indexPath, in: collectionView, using: item.cellVM)
 
-    case .tos:
-      let cell = self.dequeue(PrivacyTOSCell.self, for: indexPath, in: collectionView, using: item.cellVM)
+    case .tou:
+      let cell = self.dequeue(PrivacyTOUCell.self, for: indexPath, in: collectionView, using: item.cellVM)
       cell.userDidTapURL = { [weak self] url in self?.userDidTapURL?(url) }
       return cell
     }
@@ -252,8 +252,8 @@ extension PrivacyView: UICollectionViewDataSource {
     case .above14:
       self.userDidTapAbove14Checkbox?()
 
-    case .privacyPolicyRead:
-      self.userDidTapReadPrivacyPolicyCheckbox?()
+    case .privacyNoticeRead:
+      self.userDidTapReadPrivacyNoticeCheckbox?()
     }
   }
 }

--- a/App/UI/Settings/SettingsVC.swift
+++ b/App/UI/Settings/SettingsVC.swift
@@ -43,9 +43,9 @@ private extension SettingsVC {
     case .faq:
       self.dispatch(Logic.Settings.ShowFAQs())
     case .tos:
-      self.dispatch(Logic.Settings.ShowTOS())
+      self.dispatch(Logic.Settings.ShowTOU())
     case .privacy:
-      self.store.dispatch(Logic.Settings.ShowPrivacyPolicy())
+      self.store.dispatch(Logic.Settings.ShowPrivacyNotice())
     case .chageProvince:
       self.store.dispatch(Logic.Settings.ShowUpdateProvince())
     case .leaveReview:

--- a/AppTests/App/Logic/AppSetupLogicTests.swift
+++ b/AppTests/App/Logic/AppSetupLogicTests.swift
@@ -39,20 +39,7 @@ final class AppSetupLogicTests: XCTestCase {
     var state = AppState()
 
     // swiftlint:disable force_unwrapping
-    state.configuration = .init(
-      minimumBuildVersion: 99999,
-      serviceNotActiveNotificationPeriod: 0,
-      osForceUpdateNotificationPeriod: 0,
-      requiredUpdateNotificationPeriod: 0,
-      riskReminderNotificationPeriod: 0,
-      exposureDetectionPeriod: 0,
-      exposureConfiguration: .init(),
-      exposureInfoMinimumRiskScore: 1,
-      maximumExposureDetectionWaitingTime: 0,
-      privacyPolicyURL: URL(string: "https://unit-test")!,
-      tosURL: URL(string: "https://unit-test")!,
-      faqURL: [:]
-    )
+    state.configuration = .init(minimumBuildVersion: 99999)
     // swiftlint:enable force_unwrapping
 
     let getState = { state }

--- a/AppTests/App/Logic/AppSetupLogicTests.swift
+++ b/AppTests/App/Logic/AppSetupLogicTests.swift
@@ -38,9 +38,7 @@ final class AppSetupLogicTests: XCTestCase {
   func testChangeRootWithForceUpdate() throws {
     var state = AppState()
 
-    // swiftlint:disable force_unwrapping
     state.configuration = .init(minimumBuildVersion: 99999)
-    // swiftlint:enable force_unwrapping
 
     let getState = { state }
     let dispatchInterceptor = DispatchInterceptor()

--- a/AppTests/App/Logic/ExposureDetectionLogicTests.swift
+++ b/AppTests/App/Logic/ExposureDetectionLogicTests.swift
@@ -187,7 +187,6 @@ final class ExposureDetectionLogicTests: XCTestCase {
     }
   }
 
-
   func testUpdateUserStatusIfNecessaryIsBeingCalled() throws {
     let outcome: ExposureDetectionOutcome = .fullDetection(Date(), .noMatch, [], 0, 5)
     let state = AppState()

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ immuni:
 # Perform UI Tests for the application
 # The output will be in: UITests/Screenshots
 run_uitests: 
-	python UITests/run.py ct-app Immuni.xcworkspace Immuni true 3 en de it
+	python UITests/run.py ct-app Immuni.xcworkspace Immuni true 3 en de it fr es
 
 # Reset the project for a clean build
 reset:

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -281,7 +281,7 @@ public extension Dictionary where Key == String, Value == URL {
   /// default values for FAQs
   static var defaultFAQURL: [String: URL] {
     let values = UserLanguage.allCases.map { lang in
-      // swiftlint:disable:next implicitly_unwrapped_optional
+      // swiftlint:disable:next force_unwrapping
       (lang.rawValue, URL(string: "https://get.immuni.gov.it/docs/faq-\(lang.rawValue).json")!)
     }
 
@@ -291,7 +291,7 @@ public extension Dictionary where Key == String, Value == URL {
   /// default values for privacy notifice
   static var defaultPrivacyNoticeURL: [String: URL] {
     let values = UserLanguage.allCases.map { lang in
-      // swiftlint:disable:next implicitly_unwrapped_optional
+      // swiftlint:disable:next force_unwrapping
       (lang.rawValue, URL(string: "https://get.immuni.gov.it/docs/app-pn-\(lang.rawValue).html")!)
     }
 
@@ -301,7 +301,7 @@ public extension Dictionary where Key == String, Value == URL {
   /// default values for privacy notifice
   static var defaultTermsOfUseURL: [String: URL] {
     let values = UserLanguage.allCases.map { lang in
-      // swiftlint:disable:next implicitly_unwrapped_optional
+      // swiftlint:disable:next force_unwrapping
       (lang.rawValue, URL(string: "https://get.immuni.gov.it/docs/app-tou-\(lang.rawValue).html")!)
     }
 

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -37,9 +37,9 @@ public struct Configuration: Codable {
     case dummyIngestionMeanStochasticDelay = "dummy_teks_average_opportunity_waiting_time"
     case dummyIngestionWindowDuration = "dummy_teks_window_duration"
     case dummyIngestionAverageStartUpDelay = "dummy_teks_average_start_waiting_time"
-    case dataUploadMaxSummaryCount
-    case dataUploadMaxExposureInfoCount
-    case ingestionRequestTargetSize = "teksPacketSize"
+    case dataUploadMaxSummaryCount = "teks_max_summary_count"
+    case dataUploadMaxExposureInfoCount = "teks_max_info_count"
+    case ingestionRequestTargetSize = "teks_packet_size"
   }
 
   /// This is used to enforce a minimum version of the app.

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -26,8 +26,8 @@ public struct Configuration: Codable {
     case exposureConfiguration = "exposure_configuration"
     case exposureInfoMinimumRiskScore = "exposure_info_minimum_risk_score"
     case maximumExposureDetectionWaitingTime = "maximum_exposure_detection_waiting_time"
-    case privacyPolicyURL = "pp_url"
-    case tosURL = "tos_url"
+    case privacyNoticeURL = "pn_url"
+    case termsOfUseURL = "tou_url"
     case faqURL = "faq_url"
     case operationalInfoWithExposureSamplingRate = "operational_info_with_exposure_sampling_rate"
     case operationalInfoWithoutExposureSamplingRate = "operational_info_without_exposure_sampling_rate"
@@ -80,11 +80,17 @@ public struct Configuration: Codable {
   /// pass before a foreground session should force a new one.
   public let maximumExposureDetectionWaitingTime: TimeInterval
 
-  /// The url of the privacy policy
-  public let privacyPolicyURL: URL
+  /// The url of the privacy notice
+  /// - note: this dictionary uses string as a key because only strings and ints
+  /// are really considered as dictionaries by Codable
+  /// https://bugs.swift.org/browse/SR-7788
+  public let privacyNoticeURL: [String: URL]
 
-  /// The url of the terms of service
-  public let tosURL: URL
+  /// The url of the terms of use
+  /// - note: this dictionary uses string as a key because only strings and ints
+  /// are really considered as dictionaries by Codable
+  /// https://bugs.swift.org/browse/SR-7788
+  public let termsOfUseURL: [String: URL]
 
   /// The urls of the FAQs for the various languages
   /// - note: this dictionary uses string as a key because only strings and ints
@@ -133,6 +139,20 @@ public struct Configuration: Codable {
     return self.faqURL[language.rawValue] ?? self.faqURL[UserLanguage.english.rawValue]
   }
 
+  /// The Terms Of Use url for the given language. it returns english version if the given
+  /// language is not available.
+  /// Note that the method may still fail in case of missing english version
+  public func termsOfUseURL(for language: UserLanguage) -> URL? {
+    return self.termsOfUseURL[language.rawValue] ?? self.termsOfUseURL[UserLanguage.english.rawValue]
+  }
+
+  /// The Privacy Notice url for the given language. it returns english version if the given
+  /// language is not available.
+  /// Note that the method may still fail in case of missing english version
+  public func privacyNoticeURL(for language: UserLanguage) -> URL? {
+    return self.privacyNoticeURL[language.rawValue] ?? self.privacyNoticeURL[UserLanguage.english.rawValue]
+  }
+
 
   /// Public initializer to allow testing
   #warning("Tune default parameters")
@@ -147,13 +167,9 @@ public struct Configuration: Codable {
     exposureConfiguration: ExposureDetectionConfiguration = .init(),
     exposureInfoMinimumRiskScore: Int = 1,
     maximumExposureDetectionWaitingTime: TimeInterval = 86400,
-    privacyPolicyURL: URL = URL(string: "https://get.immuni.gov.it/app-pn.html")!,
-    tosURL: URL = URL(string: "https://get.immuni.gov.it/app-tou.html")!,
-    faqURL: [String: URL] = [
-      UserLanguage.english.rawValue: URL(string: "http://www.example.com")!,
-      UserLanguage.italian.rawValue: URL(string: "http://www.example.com")!,
-      UserLanguage.german.rawValue: URL(string: "http://www.example.com")!
-    ],
+    privacyNoticeURL: [String: URL] = .defaultPrivacyNoticeURL,
+    termsOfUseURL: [String: URL] = .defaultTermsOfUseURL,
+    faqURL: [String: URL] = .defaultFAQURL,
     operationalInfoWithExposureSamplingRate: Double = 1,
     operationalInfoWithoutExposureSamplingRate: Double = 1,
     dummyAnalyticsWaitingTime: Double = 2_592_000,
@@ -175,8 +191,8 @@ public struct Configuration: Codable {
     self.exposureConfiguration = exposureConfiguration
     self.exposureInfoMinimumRiskScore = exposureInfoMinimumRiskScore
     self.maximumExposureDetectionWaitingTime = maximumExposureDetectionWaitingTime
-    self.privacyPolicyURL = privacyPolicyURL
-    self.tosURL = tosURL
+    self.privacyNoticeURL = privacyNoticeURL
+    self.termsOfUseURL = termsOfUseURL
     self.faqURL = faqURL
     self.operationalInfoWithExposureSamplingRate = operationalInfoWithExposureSamplingRate
     self.operationalInfoWithoutExposureSamplingRate = operationalInfoWithoutExposureSamplingRate
@@ -258,5 +274,37 @@ public extension Configuration {
       self.transmissionRiskWeight = transmissionRiskWeight
       self.minimumRiskScore = minimumRiskScore
     }
+  }
+}
+
+public extension Dictionary where Key == String, Value == URL {
+  /// default values for FAQs
+  static var defaultFAQURL: [String: URL] {
+    let values = UserLanguage.allCases.map { lang in
+      // swiftlint:disable:next implicitly_unwrapped_optional
+      (lang.rawValue, URL(string: "https://get.immuni.gov.it/docs/faq-\(lang.rawValue).json")!)
+    }
+
+    return Dictionary(uniqueKeysWithValues: values)
+  }
+
+  /// default values for privacy notifice
+  static var defaultPrivacyNoticeURL: [String: URL] {
+    let values = UserLanguage.allCases.map { lang in
+      // swiftlint:disable:next implicitly_unwrapped_optional
+      (lang.rawValue, URL(string: "https://get.immuni.gov.it/docs/app-pn-\(lang.rawValue).html")!)
+    }
+
+    return Dictionary(uniqueKeysWithValues: values)
+  }
+
+  /// default values for privacy notifice
+  static var defaultTermsOfUseURL: [String: URL] {
+    let values = UserLanguage.allCases.map { lang in
+      // swiftlint:disable:next implicitly_unwrapped_optional
+      (lang.rawValue, URL(string: "https://get.immuni.gov.it/docs/app-tou-\(lang.rawValue).html")!)
+    }
+
+    return Dictionary(uniqueKeysWithValues: values)
   }
 }

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -153,10 +153,8 @@ public struct Configuration: Codable {
     return self.privacyNoticeURL[language.rawValue] ?? self.privacyNoticeURL[UserLanguage.english.rawValue]
   }
 
-
   /// Public initializer to allow testing
   #warning("Tune default parameters")
-  // swiftlint:disable force_unwrapping
   public init(
     minimumBuildVersion: Int = 0,
     serviceNotActiveNotificationPeriod: TimeInterval = 86400,

--- a/Modules/Models/FAQ.swift
+++ b/Modules/Models/FAQ.swift
@@ -549,7 +549,7 @@ public extension FAQ {
   /// German FAQs
   ///
   /// - warning: we currently don't have DE FAQs. let's fallback on english version
-  /// in the meanshile
+  /// in the meanwhile
   static let germanDefaultValues: [FAQ] = Self.englishDefaultValues
 }
 
@@ -559,7 +559,7 @@ public extension FAQ {
   /// French FAQs
   ///
   /// - warning: we currently don't have DE FAQs. let's fallback on english version
-  /// in the meanshile
+  /// in the meanwhile
   static let frenchDefaultValues: [FAQ] = Self.englishDefaultValues
 }
 
@@ -569,6 +569,6 @@ public extension FAQ {
   /// Spanish FAQs
   ///
   /// - warning: we currently don't have DE FAQs. let's fallback on english version
-  /// in the meanshile
+  /// in the meanwhile
   static let spanishDefaultValues: [FAQ] = Self.englishDefaultValues
 }

--- a/Modules/Models/FAQ.swift
+++ b/Modules/Models/FAQ.swift
@@ -552,3 +552,23 @@ public extension FAQ {
   /// in the meanshile
   static let germanDefaultValues: [FAQ] = Self.englishDefaultValues
 }
+
+// MARK: French default FAQs
+
+public extension FAQ {
+  /// French FAQs
+  ///
+  /// - warning: we currently don't have DE FAQs. let's fallback on english version
+  /// in the meanshile
+  static let frenchDefaultValues: [FAQ] = Self.englishDefaultValues
+}
+
+// MARK: Spanish default FAQs
+
+public extension FAQ {
+  /// Spanish FAQs
+  ///
+  /// - warning: we currently don't have DE FAQs. let's fallback on english version
+  /// in the meanshile
+  static let spanishDefaultValues: [FAQ] = Self.englishDefaultValues
+}

--- a/Modules/Models/UserLanguage.swift
+++ b/Modules/Models/UserLanguage.swift
@@ -15,10 +15,12 @@
 import Foundation
 
 /// The language of the user
-public enum UserLanguage: String, Codable {
+public enum UserLanguage: String, Codable, CaseIterable {
   case italian = "it"
   case english = "en"
   case german = "de"
+  case french = "fr"
+  case spanish = "es"
 
   public init(from locale: Locale) {
     guard let langCode = locale.languageCode else {

--- a/UITests/Onboarding/PrivacyUITests.swift
+++ b/UITests/Onboarding/PrivacyUITests.swift
@@ -25,32 +25,32 @@ class PrivacyUITests: AppViewTestCase, ViewTestCase {
       testCases: [
         "privacy_initial": PrivacyVM.onboardingPrivacy(
           isHeaderVisible: true,
-          tosURL: nil,
-          privacyPolicyURL: nil,
+          touURL: nil,
+          privacyNoticeURL: nil,
           isAbove14Checked: false,
           isAbove14Errored: false,
-          isReadPrivacyPolicyChecked: false,
-          isReadPrivacyPolicyErrored: false
+          isReadPrivacyNoticeChecked: false,
+          isReadPrivacyNoticeErrored: false
         ),
 
         "privacy_checked": PrivacyVM.onboardingPrivacy(
           isHeaderVisible: true,
-          tosURL: nil,
-          privacyPolicyURL: nil,
+          touURL: nil,
+          privacyNoticeURL: nil,
           isAbove14Checked: true,
           isAbove14Errored: false,
-          isReadPrivacyPolicyChecked: true,
-          isReadPrivacyPolicyErrored: false
+          isReadPrivacyNoticeChecked: true,
+          isReadPrivacyNoticeErrored: false
         ),
 
         "privacy_errored": PrivacyVM.onboardingPrivacy(
           isHeaderVisible: true,
-          tosURL: nil,
-          privacyPolicyURL: nil,
+          touURL: nil,
+          privacyNoticeURL: nil,
           isAbove14Checked: false,
           isAbove14Errored: true,
-          isReadPrivacyPolicyChecked: false,
-          isReadPrivacyPolicyErrored: true
+          isReadPrivacyNoticeChecked: false,
+          isReadPrivacyNoticeErrored: true
         ),
 
         "settings_privacy": PrivacyVM.settingsPrivacy(isHeaderVisible: false),


### PR DESCRIPTION
## Description

This PR fixes the naming of the TOS (now TOU) and Privacy Policy (now Privacy Notice) and introduces missing languages

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [X] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket:
