### PR TITLE
chore: add danger checks for branches

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -36,7 +36,7 @@ export default async () => {
     );
   } else if (isDestinationMaster && isReleaseBranch) {
     warn(
-      "This PR repreents an App Store release and it should be merged only when this version has been release on the store"
+      "This PR represents an App Store release and it should be merged only when this version has been released on the store"
     );
   }
 

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import { danger, warn, message, fail } from "danger";
+import { danger, warn, message } from "danger";
 import { checkFormat } from "./CI/danger/swiftformat";
 import { checkLinting } from "./CI/danger/swiftlint";
 import { isAppFile, isTestFile } from "./CI/danger/utils";
@@ -31,12 +31,12 @@ export default async () => {
   const isReleaseBranch = danger.github.pr.head.ref.indexOf("release/") !== -1;
 
   if (isDestinationMaster && !isReleaseBranch) {
-    fail(
-      "This PR has been opened against master, but the current branch is not a release one. Most likely you need to change destination branch"
+    warn(
+      "This PR has been opened against master, but the current branch is not a release one. Most likely you need to change destination branch."
     );
   } else if (isDestinationMaster && isReleaseBranch) {
     warn(
-      "This PR represents an App Store release and it should be merged only when this version has been released on the store"
+      "This PR represents an App Store release and it should be merged only when this version has been released on the store."
     );
   }
 

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -12,9 +12,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import { danger, warn, message } from "danger";
+import { danger, warn, message, fail } from "danger";
 import { checkFormat } from "./CI/danger/swiftformat";
-import { checkLinting} from "./CI/danger/swiftlint";
+import { checkLinting } from "./CI/danger/swiftlint";
 import { isAppFile, isTestFile } from "./CI/danger/utils";
 import commitLint from "./CI/danger/commitlint";
 
@@ -27,14 +27,25 @@ export default async () => {
   const hasChangedTests =
     danger.git.modified_files.filter(isTestFile).length > 0;
 
+  const isDestinationMaster = danger.github.pr.base.ref === "master";
+  const isReleaseBranch = danger.github.pr.head.ref.indexOf("release/") !== -1;
+
+  if (isDestinationMaster && !isReleaseBranch) {
+    fail(
+      "This PR has been opened against master, but the current branch is not a release one. Most likely you need to change destination branch"
+    );
+  } else if (isDestinationMaster && isReleaseBranch) {
+    warn(
+      "This PR repreents an App Store release and it should be merged only when this version has been release on the store"
+    );
+  }
+
   message(
     "Thank you for submitting a pull request! The team will review your submission as soon as possible."
   );
 
   if (hasChangedApp && !hasChangedTests) {
-    warn(
-      "Consider adding tests or updating existing tests for your changes."
-    );
+    warn("Consider adding tests or updating existing tests for your changes.");
   }
 
   await commitLint({ enabled: true, allowedScopes: [] });


### PR DESCRIPTION
## Description

This PR adds two checks for danger:
- when a pr is toward master, but the branch is not a release one, an error is shown

- when a or is toward master and the branch is a release one, a warning is added