### PR TITLE
fix: remove repeated risk notification

### DIFF
--- a/App/Logic/CovidStatusLogic.swift
+++ b/App/Logic/CovidStatusLogic.swift
@@ -99,20 +99,10 @@ extension Logic.CovidStatus {
         return
       }
 
-      // If a contact with a positive user is detected, the user is notified
-      manager.scheduleLocalNotification(
-        .init(
-          title: L10n.Notifications.Risk.title,
-          body: L10n.Notifications.Risk.description,
-          userInfo: [:],
-          identifier: RiskNotificationID.contactHappened.rawValue
-        ),
-        with: .timeInterval(10)
-      )
-
-      // Add a periodic reminder in case the notification is
-      // not seen. This reminder is removed either on state change or
-      // when the app is opened
+      // If a contact with a positive user is detected, it must be the result of a full cycle of exposure detection (i.e.
+      // detection with ExposureInfo), which already causes the operative system to immediately notify the user.
+      // On top of this, a periodic reminder is added in case the user has not opened the app since having entered the Risk
+      // state. This reminder is removed either on state change or when the app is opened.
       manager.scheduleLocalNotification(
         .init(
           title: L10n.Notifications.Risk.title,

--- a/App/Logic/CovidStatusLogic.swift
+++ b/App/Logic/CovidStatusLogic.swift
@@ -53,7 +53,6 @@ extension Logic.CovidStatus {
 
   /// The ids of the covid status update notifications
   static let covidNotificationIDs = [
-    Logic.CovidStatus.RiskNotificationID.contactHappened.rawValue,
     Logic.CovidStatus.RiskNotificationID.contactReminder.rawValue,
     Logic.CovidStatus.PositiveNotificationID.updateStatus.rawValue
   ]
@@ -74,7 +73,6 @@ extension Logic.CovidStatus {
 extension Logic.CovidStatus {
   /// IDs to identify the notifications
   private enum RiskNotificationID: String {
-    case contactHappened = "risk_contact_notification_id"
     case contactReminder = "risk_reminder_notification_id"
   }
 


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description
This PR removes the first risk notification, which is already delivered by iOS when a full detection is performed.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes
- Addresses #80
