### PR TITLE
feat: prevent the app from accessing exposure info

### DIFF
--- a/App/Logic/ExposureDetectionLogic.swift
+++ b/App/Logic/ExposureDetectionLogic.swift
@@ -56,6 +56,7 @@ extension Logic.ExposureDetection {
         enManager: context.dependencies.exposureNotificationManager,
         tekProvider: context.dependencies.temporaryExposureKeyProvider,
         now: context.dependencies.now,
+        isUserCovidPositive: state.user.covidStatus.isCovidPositive,
         forceRun: self.forceRun
       ))
 

--- a/AppTests/App/Dependencies/ImmuniExposureDetectionExecutorTests.swift
+++ b/AppTests/App/Dependencies/ImmuniExposureDetectionExecutorTests.swift
@@ -48,6 +48,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: enManager,
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: true
     )
     promise.run()
@@ -87,6 +88,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: enManager,
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: true
     )
 
@@ -112,6 +114,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: MockExposureNotificationProvider(overriddenStatus: .authorizedAndActive)),
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: false
     )
     promise.run()
@@ -135,6 +138,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: MockExposureNotificationProvider(overriddenStatus: .authorized)),
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 0),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: true
     )
     promise.run()
@@ -159,6 +163,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: NoMatchMockExposureNotificationProvider(overriddenStatus: .authorized)),
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: true
     )
 
@@ -184,6 +189,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: NoMatchMockExposureNotificationProvider(overriddenStatus: .authorized)),
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: false
     )
 
@@ -209,6 +215,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: MatchingMockExposureNotificationProvider(overriddenStatus: .authorized)),
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: true
     )
 
@@ -234,6 +241,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: MatchingMockExposureNotificationProvider(overriddenStatus: .authorized)),
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: false
     )
 
@@ -259,6 +267,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: MatchingMockExposureNotificationProvider(overriddenStatus: .authorized)),
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: false
     )
 
@@ -287,6 +296,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: MatchingMockExposureNotificationProvider(overriddenStatus: .authorized)),
       tekProvider: tekProvider,
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: false
     )
 
@@ -314,6 +324,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: MatchingMockExposureNotificationProvider(overriddenStatus: .authorized)),
       tekProvider: tekProvider,
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: true
     )
 
@@ -338,6 +349,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: MatchingMockExposureNotificationProvider(overriddenStatus: .notAuthorized)),
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: false
     )
 
@@ -365,6 +377,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: MatchingMockExposureNotificationProvider(overriddenStatus: .authorized)),
       tekProvider: ThrowingMockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: false
     )
 
@@ -392,6 +405,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: ThrowingOnDetectExposuresMockExposureNotificationProvider()),
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: false
     )
 
@@ -419,6 +433,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: ThrowingOnGetExposureInfoMockExposureNotificationProvider()),
       tekProvider: MockTemporaryExposureKeyProvider(urlsToReturn: 1),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: false
     )
 
@@ -449,6 +464,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: NoMatchMockExposureNotificationProvider(overriddenStatus: .authorized)),
       tekProvider: MockTemporaryExposureKeyProvider(minIndexToReturn: minIndex, maxIndexToReturn: maxIndex),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: false
     )
 
@@ -481,6 +497,7 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
       enManager: .init(provider: MatchingMockExposureNotificationProvider(overriddenStatus: .authorized)),
       tekProvider: MockTemporaryExposureKeyProvider(minIndexToReturn: minIndex, maxIndexToReturn: maxIndex),
       now: { Date() },
+      isUserCovidPositive: false,
       forceRun: true
     )
 
@@ -491,6 +508,39 @@ final class ImmuniExposureDetectionExecutorTests: XCTestCase {
     let outcome = try XCTUnwrap(promise.result)
 
     XCTAssertEqual(outcome.rawCase, .fullDetection)
+
+    let (outcomeMinIndex, outcomeMaxIndex) = try XCTUnwrap(outcome.processedChunkBoundaries)
+    XCTAssertEqual(outcomeMinIndex, minIndex)
+    XCTAssertEqual(outcomeMaxIndex, maxIndex)
+  }
+
+  func testPreventFullDetectionWhenPositive() throws {
+    let executor = ImmuniExposureDetectionExecutor()
+
+    let minIndex = 4
+    let maxIndex = 6
+
+    let promise = executor.execute(
+      exposureDetectionPeriod: 0,
+      lastExposureDetectionDate: nil,
+      latestProcessedKeyChunkIndex: nil,
+      exposureDetectionConfiguration: .init(),
+      exposureInfoRiskScoreThreshold: 0,
+      userExplanationMessage: "this is a test",
+      enManager: .init(provider: MatchingMockExposureNotificationProvider(overriddenStatus: .authorized)),
+      tekProvider: MockTemporaryExposureKeyProvider(minIndexToReturn: minIndex, maxIndexToReturn: maxIndex),
+      now: { Date() },
+      isUserCovidPositive: true,
+      forceRun: false
+    )
+
+    promise.run()
+
+    expectToEventually(!promise.isPending)
+    XCTAssertNil(promise.error)
+    let outcome = try XCTUnwrap(promise.result)
+
+    XCTAssertEqual(outcome.rawCase, .partialDetection)
 
     let (outcomeMinIndex, outcomeMaxIndex) = try XCTUnwrap(outcome.processedChunkBoundaries)
     XCTAssertEqual(outcomeMinIndex, minIndex)

--- a/AppTests/ImmuniExposureNotification/ExposureNotificationMocks.swift
+++ b/AppTests/ImmuniExposureNotification/ExposureNotificationMocks.swift
@@ -243,6 +243,7 @@ class MockExposureDetectionExecutor: ExposureDetectionExecutor {
     enManager: ExposureNotificationManager,
     tekProvider: TemporaryExposureKeyProvider,
     now: @escaping () -> Date,
+    isUserCovidPositive: Bool,
     forceRun: Bool
   ) -> Promise<ExposureDetectionOutcome> {
     self.executeMethodCalls += 1

--- a/Modules/ImmuniExposureNotification/ExposureDetectionExecutor.swift
+++ b/Modules/ImmuniExposureNotification/ExposureDetectionExecutor.swift
@@ -29,6 +29,7 @@ public protocol ExposureDetectionExecutor {
     enManager: ExposureNotificationManager,
     tekProvider: TemporaryExposureKeyProvider,
     now: @escaping () -> Date,
+    isUserCovidPositive: Bool,
     forceRun: Bool
   ) -> Promise<ExposureDetectionOutcome>
 }

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -156,7 +156,7 @@ public struct Configuration: Codable {
   /// Public initializer to allow testing
   public init(
     minimumBuildVersion: Int = 1,
-    serviceNotActiveNotificationPeriod: TimeInterval = 43200,
+    serviceNotActiveNotificationPeriod: TimeInterval = 86400,
     osForceUpdateNotificationPeriod: TimeInterval = 86400,
     requiredUpdateNotificationPeriod: TimeInterval = 86400,
     riskReminderNotificationPeriod: TimeInterval = 86400,
@@ -172,9 +172,9 @@ public struct Configuration: Codable {
     dummyAnalyticsWaitingTime: Double = 2_592_000,
     dummyIngestionAverageRequestWaitingTime: Double = 10,
     dummyIngestionRequestProbabilities: [Double] = [0.95, 0.1],
-    dummyIngestionMeanStochasticDelay: Double = 2_592_000,
-    dummyIngestionWindowDuration: Double = 259_200,
-    dummyIngestionAverageStartUpDelay: Double = 10,
+    dummyIngestionMeanStochasticDelay: Double = 5_184_000,
+    dummyIngestionWindowDuration: Double = 1_209_600,
+    dummyIngestionAverageStartUpDelay: Double = 15,
     dataUploadMaxSummaryCount: Int = 84,
     dataUploadMaxExposureInfoCount: Int = 600,
     ingestionRequestTargetSize: Int = 110_000

--- a/Modules/Models/CovidStatus/CovidStatus.swift
+++ b/Modules/Models/CovidStatus/CovidStatus.swift
@@ -26,6 +26,18 @@ public enum CovidStatus {
   /// The user is positive to COVID-19. This state is inferred from the `data upload`
   /// functionality (that is, TEKs upload)
   case positive(lastUpload: CalendarDay)
+
+  /// Whether the state represents a positive
+  /// state to covid
+  public var isCovidPositive: Bool {
+    switch self {
+    case .risk, .neutral:
+      return false
+
+    case .positive:
+      return true
+    }
+  }
 }
 
 // MARK: Extensions


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

When a user is positive, the app shouldn't send any additional notification. While the app's logic already does that, it sometimes accesses to the EN manager to retrieve the Exposure Info. This triggers an automatic notification that we cannot prevent. This PR prevents the logic from accessing Exposure Info when a user is positive.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [X] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket:

