### PR TITLE
Feature/commitlint pre hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ The source code should be linted using [SwiftLint](https://github.com/realm/Swif
 
 We have decided not to include the linter or the formatter as build phases to prevent increasing the application build time. However, there are some helpers in place.
 
-If you have set up the project using Make setup, the script has installed a _pre-commit hook_ on your git folder. You can check it in the [Makefile](Makefile). This script automatically formats the source code and solves most of the linting issues. If the linter finds issues that it cannot fix automatically, the commit fails. If you prefer not to have this mechanism in place, either do not set up the project using make setup or delete the .`git/hooks/pre-commit` file. However, we recommend running these commands before each commit.
+If you have set up the project using Make setup, the script has installed a _pre-commit hook_ and a _commit_msg hook_on your git folder, to validate you can check it in the [Makefile](Makefile). This script automatically formats the source code and solves most of the linting issues. If the linter finds issues that it cannot fix automatically, the commit fails. Same happens for commit messages : if the format `<type>: <commit message>` is not respected. If you prefer not to have this mechanism in place, either do not set up the project using make setup or delete the .`git/hooks/pre-commit` file. However, we recommend running these commands before each commit.
 
 ```sh
 swiftformat .

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ setup:
 	brew bundle
 	eval "$$add_pre_commit_script"
 	npm install -g @commitlint/cli @commitlint/config-conventional
+	sed -e "/^[//].*/d" -e "s/export default/module.exports = { rules: /g" -e "s/};/}};/g" -e "/^$$/d" CI/danger/commitlint/rules.ts > commitlint.config.js
 	eval "$$add_commit_msg_script"
 
 ###

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ setup:
 	gem install cocoapods -v 1.9.1
 	brew bundle
 	eval "$$add_pre_commit_script"
+	npm install -g @commitlint/cli @commitlint/config-conventional
+	eval "$$add_commit_msg_script"
 
 ###
 
@@ -70,3 +72,16 @@ ENDOFFILE
 chmod +x .git/hooks/pre-commit
 endef
 export add_pre_commit_script = $(value _add_pre_commit)
+
+# Define commit msg script to auto check commit msg
+define _add_commit_msg
+
+cat > .git/hooks/commit-msg << ENDOFFILE
+#!/bin/sh
+
+cat \$1 | commitlint
+ENDOFFILE
+
+chmod +x .git/hooks/commit-msg
+endef
+export add_commit_msg_script = $(value _add_commit_msg) 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,37 @@
+module.exports = {
+	rules: {
+        "scope-enum": [2, "always"],
+        "body-leading-blank": [1, "always"],
+        "body-max-line-length": [2, "always", 100],
+        "footer-leading-blank": [1, "always"],
+        "footer-max-line-length": [2, "always", 100],
+        "header-max-length": [2, "always", 100],
+        "scope-case": [2, "always", "lower-case"],
+        "subject-case": [
+            2,
+            "never",
+            ["sentence-case", "start-case", "pascal-case", "upper-case"]
+        ],
+        "subject-empty": [2, "never"],
+        "subject-full-stop": [2, "never", "."],
+        "type-case": [2, "always", "lower-case"],
+        "type-empty": [2, "never"],
+        "type-enum": [
+            2,
+            "always",
+            [
+                "build",
+                "chore",
+                "ci",
+                "docs",
+                "feat",
+                "fix",
+                "perf",
+                "refactor",
+                "revert",
+                "style",
+                "test"
+            ]
+        ]
+    }
+}; 


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

As mentioned in issue #56 [FEAT] CommitLint pre-hook  , a desiderable feature is to have a lint checker on commit messages also on the local development environment to prevent eventual errors be arised only at CI occurrence.

Here my proposal to adopt a solution similar to what was already being done for .sift files linting exploiting commit-msg hook , unluckily the solution adopted to copy rules from `CI` folder is not the cleanest and I am not 100% happy about that. I am still struggling for a smarter method, I would be more than happy to accept suggestions.
This PR tackles:

- #56 

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [ ] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

<!-- Please insert the issue numbers after the # symbol -->

- Fixes #56 
