### PR TITLE
typo: Ok -> OK

### DIFF
--- a/App/Dependencies/AppDependencies+DebugMenu.swift
+++ b/App/Dependencies/AppDependencies+DebugMenu.swift
@@ -182,7 +182,7 @@
             message: message,
             preferredStyle: .alert,
             actions: [
-              .init(title: "Ok", style: .default)
+              .init(title: "OK", style: .default)
             ]
           )
         )
@@ -221,7 +221,7 @@
         model: .init(
           title: resultTitle,
           message: resultMessage,
-          actions: [.init(title: "Ok")]
+          actions: [.init(title: "OK")]
         )
       ))
     }
@@ -257,7 +257,7 @@
         model: .init(
           title: resultTitle,
           message: resultMessage,
-          actions: [.init(title: "Ok")]
+          actions: [.init(title: "OK")]
         )
       ))
     }
@@ -281,7 +281,7 @@
         model: .init(
           title: "Result",
           message: message,
-          actions: [.init(title: "Ok")]
+          actions: [.init(title: "OK")]
         )
       ))
     }


### PR DESCRIPTION
In DebugMenu fix typo: `Ok` -> `OK`

