### PR TITLE
fix: collections ui

### DIFF
--- a/App/UI/Home/HomeView.swift
+++ b/App/UI/Home/HomeView.swift
@@ -100,7 +100,7 @@ class HomeView: UIView, ViewControllerModellableView {
 
   private func afterLayout() {
     self.collection.contentInset.top = -self.universalSafeAreaInsets.top
-    self.collection.contentInset.bottom = self.universalSafeAreaInsets.bottom + 50
+    self.collection.contentInset.bottom = 20
     guard let collectionViewLayout = self.collection.collectionViewLayout as? UICollectionViewFlowLayout else {
       return
     }
@@ -121,6 +121,7 @@ private extension HomeView {
     static func collection(_ collectionView: UICollectionView) {
       collectionView.backgroundColor = Palette.grayWhite
       collectionView.showsVerticalScrollIndicator = false
+      collectionView.alwaysBounceVertical = true
     }
   }
 }

--- a/App/UI/Settings/SettingsView.swift
+++ b/App/UI/Settings/SettingsView.swift
@@ -205,6 +205,7 @@ class SettingsView: UIView, ViewControllerModellableView {
 
   private func updateAfterLayout() {
     self.collection.contentInset.top = self.headerTitle.frame.maxY - self.universalSafeAreaInsets.top
+    self.collection.contentInset.bottom = 20
     guard let collectionViewLayout = self.collection.collectionViewLayout as? UICollectionViewFlowLayout else {
       return
     }
@@ -229,7 +230,6 @@ private extension SettingsView {
 
     static func collection(_ collectionView: UICollectionView) {
       collectionView.backgroundColor = .clear
-      collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 50, right: 0)
       collectionView.showsVerticalScrollIndicator = false
     }
 

--- a/App/UI/Suggestions/Cells/SuggestionsHeaderCell.swift
+++ b/App/UI/Suggestions/Cells/SuggestionsHeaderCell.swift
@@ -134,7 +134,11 @@ class SuggestionsHeaderCell: UICollectionViewCell, ModellableView, ReusableView,
   }
 
   var minimumHeight: CGFloat {
-    return 77
+    guard let suggestionsView = self.superview?.superview as? SuggestionsView else {
+      return 77
+    }
+    // return the height of the header view to support all font sizes.
+    return suggestionsView.headerView.bounds.height
   }
 
   override func layoutSubviews() {

--- a/App/UI/Suggestions/SuggestionView.swift
+++ b/App/UI/Suggestions/SuggestionView.swift
@@ -27,7 +27,7 @@ class SuggestionsView: UIView, ViewControllerModellableView {
   private let background = GradientView()
   let collection = UICollectionView(frame: .zero, collectionViewLayout: CollectionWithStickyCellsLayout())
   private let headerContainer = UIView()
-  private let headerView = GradientView()
+  let headerView = GradientView()
   private let headerTitleView = UILabel()
   private var closeButton = ImageButton()
 


### PR DESCRIPTION
## Description

This PR fixes a couple of UI issue related to collections.

This PR tackles:
- an issue with the suggestions header when `UIContentSizeCategory` is set to `small` or `extra small`
- main tabs collection content insets

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes:

- addresses #135 
- addresses #146
