### PR TITLE
fix: correctly handle case with one chunk

### DIFF
--- a/App/Dependencies/ExposureDetection/ImmuniTemporaryExposureKeyProvider.swift
+++ b/App/Dependencies/ExposureDetection/ImmuniTemporaryExposureKeyProvider.swift
@@ -65,7 +65,7 @@ class ImmuniTemporaryExposureKeyProvider: TemporaryExposureKeyProvider {
 
         guard
           keysIndex.newest > latestKnown,
-          keysIndex.newest > keysIndex.oldest
+          keysIndex.newest >= keysIndex.oldest
           else {
             // no chunks to download
             return []

--- a/AppTests/App/Dependencies/ImmuniTemporaryExposureKeyProviderTests.swift
+++ b/AppTests/App/Dependencies/ImmuniTemporaryExposureKeyProviderTests.swift
@@ -103,6 +103,23 @@ final class ImmuniTemporaryExposureKeyProviderTests: XCTestCase {
 
     XCTAssertEqual(chunks.count, 0)
   }
+
+  func testReturnsCorrectValuesIfOnlyOneChunk() throws {
+    let chunk = 8
+    let mockedExecutor = MockRequestExecutor(mockedResult: .success(KeysIndex(oldest: chunk, newest: chunk)))
+    let networkManager = NetworkManager()
+    networkManager.start(with: .init(requestExecutor: mockedExecutor, now: { Date() }))
+
+    let keyProvider = ImmuniTemporaryExposureKeyProvider(networkManager: networkManager, fileStorage: MockFileStorage())
+
+    let promise = keyProvider.getMissingChunksIndexes(latestKnownChunkIndex: nil)
+
+    expectToEventually(promise.isPending == false)
+
+    let chunks = try XCTUnwrap(promise.result)
+
+    XCTAssertEqual(chunks, [chunk])
+  }
 }
 
 private struct MockFileStorage: FileStorage {


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description
This PR tackles a bug in which the exposure detection was not being performed in case the backend was returning only a single chunk.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
