### PR TITLE
feat: remove notifications when they’re not longer needed

### DIFF
--- a/App/Logic/LifecycleLogic.swift
+++ b/App/Logic/LifecycleLogic.swift
@@ -129,6 +129,9 @@ extension Logic {
 
         // refresh statuses
         try context.awaitDispatch(RefreshAuthorizationStatuses())
+
+        /// removes uneeded notifications
+        try context.awaitDispatch(Logic.ExposureDetection.RemoveLocalNotificationIfNotNeeded())
       }
     }
 
@@ -172,6 +175,9 @@ extension Logic {
       func sideEffect(_ context: SideEffectContext<AppState, AppDependencies>) throws {
         // clears `PositiveExposureResults` older than 14 days from the `ExposureDetectionState`
         try context.awaitDispatch(Logic.ExposureDetection.ClearOutdatedResults(now: context.dependencies.now()))
+
+        /// removes uneeded notifications
+        try context.awaitDispatch(Logic.ExposureDetection.RemoveLocalNotificationIfNotNeeded())
 
         // updates the ingestion dummy traffic opportunity window if it expired
         try context.awaitDispatch(Logic.DataUpload.UpdateDummyTrafficOpportunityWindowIfExpired())

--- a/Modules/PushNotification/PushNotification.swift
+++ b/Modules/PushNotification/PushNotification.swift
@@ -100,6 +100,12 @@ public final class PushNotificationManager {
   public func scheduledLocalNotificationsIds() -> Promise<[String]> {
     return self.localNotificationScheduler.scheduledNotificationsIds()
   }
+
+  /// Removes the delivered notifications with the given identifiers
+  /// from the Notification Center
+  public func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
+    self.localNotificationScheduler.removeDeliveredNotifications(withIdentifiers: identifiers)
+  }
 }
 
 private extension PushNotificationManager {

--- a/Modules/PushNotification/Utility/LocalNotificationScheduler.swift
+++ b/Modules/PushNotification/Utility/LocalNotificationScheduler.swift
@@ -111,6 +111,9 @@ public protocol LocalNotificationScheduler {
 
   /// Returns all the currently scheduled notification ids
   func scheduledNotificationsIds() -> Promise<[String]>
+
+  /// Removes delivered notifications with the given ids
+  func removeDeliveredNotifications(withIdentifiers identifiers: [String])
 }
 
 class ConcreteLocalNotificationScheduler: LocalNotificationScheduler {
@@ -146,6 +149,11 @@ class ConcreteLocalNotificationScheduler: LocalNotificationScheduler {
         resolve(ids)
       }
     }
+  }
+
+  func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
+    let center = UNUserNotificationCenter.current()
+    center.removeDeliveredNotifications(withIdentifiers: identifiers)
   }
 }
 


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

This PR implements a logic that removes the "service not active" push notification once it is not longer needed

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [X] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket:
