### PR TITLE
feat: enable tap on whole card

### DIFF
--- a/App/UI/Home/Cells/HomeServiceActiveCell.swift
+++ b/App/UI/Home/Cells/HomeServiceActiveCell.swift
@@ -75,8 +75,8 @@ class HomeServiceActiveCell: UICollectionViewCell, ModellableView, ReusableView,
   let shieldCheckmark = AnimationView()
   let shieldShadow = AnimationView()
   let disabledShield = AnimationView()
+  let discoverMore = UILabel()
   var actionButton = ButtonWithInsets()
-  var discoverMore = UILabel()
 
   var didTapAction: Interaction?
 
@@ -113,6 +113,8 @@ class HomeServiceActiveCell: UICollectionViewCell, ModellableView, ReusableView,
     self.actionButton.on(.touchUpInside) { [weak self] _ in
       self?.didTapAction?()
     }
+
+    self.discoverMore.accessibilityTraits = .button
   }
 
   func style() {

--- a/App/UI/Home/Cells/HomeServiceActiveCell.swift
+++ b/App/UI/Home/Cells/HomeServiceActiveCell.swift
@@ -76,10 +76,9 @@ class HomeServiceActiveCell: UICollectionViewCell, ModellableView, ReusableView,
   let shieldShadow = AnimationView()
   let disabledShield = AnimationView()
   var actionButton = ButtonWithInsets()
-  var discoverMoreButton = TextButton()
+  var discoverMore = UILabel()
 
   var didTapAction: Interaction?
-  var didTapDiscoverMore: Interaction?
 
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -109,14 +108,10 @@ class HomeServiceActiveCell: UICollectionViewCell, ModellableView, ReusableView,
     self.container.addSubview(self.shieldCheckmark)
     self.container.addSubview(self.disabledShield)
     self.container.addSubview(self.actionButton)
-    self.container.addSubview(self.discoverMoreButton)
+    self.container.addSubview(self.discoverMore)
 
     self.actionButton.on(.touchUpInside) { [weak self] _ in
       self?.didTapAction?()
-    }
-
-    self.discoverMoreButton.on(.touchUpInside) { [weak self] _ in
-      self?.didTapDiscoverMore?()
     }
   }
 
@@ -126,7 +121,7 @@ class HomeServiceActiveCell: UICollectionViewCell, ModellableView, ReusableView,
 
     Self.Style.container(self.container)
     Self.Style.statusBarBackground(self.statusBarBackground)
-    Self.Style.discoverMore(self.discoverMoreButton, content: L10n.HomeView.Service.Active.discoverMore)
+    Self.Style.discoverMore(self.discoverMore, content: L10n.HomeView.Service.Active.discoverMore)
     Self.Style.logo(self.logo)
     Self.Style.shieldShadow(self.shieldShadow)
     Self.Style.shieldCheckmark(self.shieldCheckmark)
@@ -141,7 +136,7 @@ class HomeServiceActiveCell: UICollectionViewCell, ModellableView, ReusableView,
     self.shieldShadow.isHidden = !model.isServiceActive
     self.shieldCheckmark.isHidden = !model.isServiceActive
     self.disabledShield.isHidden = model.isServiceActive
-    self.discoverMoreButton.isHidden = !model.isServiceActive
+    self.discoverMore.isHidden = !model.isServiceActive
     self.statusBarBackground.isHidden = model.hasHeaderCard
     self.actionButton.isHidden = model.isServiceActive
 
@@ -193,7 +188,7 @@ class HomeServiceActiveCell: UICollectionViewCell, ModellableView, ReusableView,
       .minHeight(53)
       .bottom(HomeView.cellHorizontalInset)
 
-    self.discoverMoreButton.pin
+    self.discoverMore.pin
       .horizontally(HomeView.cellHorizontalInset)
       .sizeToFit(.widthFlexible)
       .bottom(HomeServiceActiveCell.verticalOffset)
@@ -203,7 +198,7 @@ class HomeServiceActiveCell: UICollectionViewCell, ModellableView, ReusableView,
         .left(HomeView.cellHorizontalInset)
         .right(Self.titleRightMargin)
         .sizeToFit(.width)
-        .above(of: self.discoverMoreButton)
+        .above(of: self.discoverMore)
         .marginBottom(Self.subtitleToDiscoverMore)
     } else {
       self.subtitle.pin
@@ -258,7 +253,7 @@ class HomeServiceActiveCell: UICollectionViewCell, ModellableView, ReusableView,
     let titleSize = self.title.sizeThatFits(CGSize(width: labelWidth, height: CGFloat.infinity))
     let subtitleSize = self.subtitle.sizeThatFits(CGSize(width: labelWidth, height: CGFloat.infinity))
     let firstCellOffset: CGFloat = (self.model?.hasHeaderCard ?? false) ? 0 : topSafeArea
-    let discoverMoreSize = self.discoverMoreButton.sizeThatFits(CGSize(width: labelWidth, height: CGFloat.infinity))
+    let discoverMoreSize = self.discoverMore.sizeThatFits(CGSize(width: labelWidth, height: CGFloat.infinity))
 
     return CGSize(
       width: size.width,
@@ -372,14 +367,16 @@ private extension HomeServiceActiveCell {
       imageView.setAccessibilityLabel(L10n.Accessibility.appName)
     }
 
-    static func discoverMore(_ button: TextButton, content: String) {
+    static func discoverMore(_ label: UILabel, content: String) {
       let style = TextStyles.pSemibold.byAdding(
         .color(Palette.primary)
       )
 
-      button.attributedTitle = content.styled(with: style)
-      button.contentHorizontalAlignment = .left
-      button.titleLabel?.numberOfLines = 0
+      TempuraStyles.styleStandardLabel(
+        label,
+        content: content,
+        style: style
+      )
     }
   }
 }

--- a/App/UI/Home/HomeView.swift
+++ b/App/UI/Home/HomeView.swift
@@ -158,7 +158,6 @@ extension HomeView: UICollectionViewDataSource, UICollectionViewDelegateFlowLayo
       let cell = collectionView.dequeueReusableCell(HomeServiceActiveCell.self, for: indexPath)
       cell.model = cellModel as? HomeServiceActiveCellVM
       cell.didTapAction = { [weak self] in self?.didTapActivateService?() }
-      cell.didTapDiscoverMore = { [weak self] in self?.didTapActiveServiceDiscoverMore?() }
       return cell
 
     case .infoHeader:
@@ -196,7 +195,9 @@ extension HomeView: UICollectionViewDataSource, UICollectionViewDelegateFlowLayo
     switch cellType {
     case .header:
       self.didTapHeaderCardInfo?()
-    case .serviceActiveCard:
+    case .serviceActiveCard(true):
+      self.didTapActiveServiceDiscoverMore?()
+    case .serviceActiveCard(false):
       self.didTapActivateService?()
     case .infoHeader:
       return

--- a/Modules/Models/Configuration.swift
+++ b/Modules/Models/Configuration.swift
@@ -318,7 +318,7 @@ public extension Dictionary where Key == String, Value == URL {
   static var defaultPrivacyNoticeURL: [String: URL] {
     let values = UserLanguage.allCases.map { lang in
       // swiftlint:disable:next force_unwrapping
-      (lang.rawValue, URL(string: "https://get.immuni.gov.it/docs/app-pn-\(lang.rawValue).html")!)
+      (lang.rawValue, URL(string: "https://www.immuni.italia.it/app-pn.html")!)
     }
 
     return Dictionary(uniqueKeysWithValues: values)
@@ -328,7 +328,7 @@ public extension Dictionary where Key == String, Value == URL {
   static var defaultTermsOfUseURL: [String: URL] {
     let values = UserLanguage.allCases.map { lang in
       // swiftlint:disable:next force_unwrapping
-      (lang.rawValue, URL(string: "https://get.immuni.gov.it/docs/app-tou-\(lang.rawValue).html")!)
+      (lang.rawValue, URL(string: "https://www.immuni.italia.it/app-tou.html")!)
     }
 
     return Dictionary(uniqueKeysWithValues: values)


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

The PR adds the tap on the whole card in home, instead of just having the tap on "discover more"

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [X] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket:
