### PR TITLE
fix: use static expected asset height

### DIFF
--- a/App/UI/Onboarding/Advice/OnboardingAdviceView.swift
+++ b/App/UI/Onboarding/Advice/OnboardingAdviceView.swift
@@ -21,11 +21,11 @@ import Tempura
 
 class OnboardingAdviceView: UIView, ViewControllerModellableView {
   private static let verticalSpacing: CGFloat = UIDevice.getByScreen(normal: 25, narrow: 10)
-
   private static let horizontalSpacing: CGFloat = UIDevice.getByScreen(
     normal: OnboardingContainerAccessoryView.horizontalSpacing,
     narrow: OnboardingContainerAccessoryView.horizontalSpacing / 2.0
   )
+  private static let expectedAssetHeight: CGFloat = 375
 
   private let detailsLabel = UILabel()
   private let titleLabel = UILabel()
@@ -89,10 +89,9 @@ class OnboardingAdviceView: UIView, ViewControllerModellableView {
   }
 
   private func updateAfterLayout() {
-    let contentSize = self.animation.intrinsicContentSize
     let realContentViewSize = self.animation.frame.size
 
-    let isContentRelevant = (realContentViewSize.height / contentSize.height) > 0.3
+    let isContentRelevant = (realContentViewSize.height / Self.expectedAssetHeight) > 0.3
     self.animation.alpha = isContentRelevant.cgFloat
   }
 }

--- a/App/UI/Onboarding/Permission/OnboardingPermissionView.swift
+++ b/App/UI/Onboarding/Permission/OnboardingPermissionView.swift
@@ -21,11 +21,11 @@ import Tempura
 
 class OnboardingPermissionView: UIView, ViewControllerModellableView {
   private static let verticalSpacing: CGFloat = UIDevice.getByScreen(normal: 25, narrow: 10)
-
   private static let horizontalSpacing: CGFloat = UIDevice.getByScreen(
     normal: OnboardingContainerAccessoryView.horizontalSpacing,
     narrow: OnboardingContainerAccessoryView.horizontalSpacing / 2.0
   )
+  private static let expectedAssetHeight: CGFloat = 375
 
   // MARK: - Subviews
 
@@ -122,10 +122,9 @@ class OnboardingPermissionView: UIView, ViewControllerModellableView {
   }
 
   private func updateAfterLayout() {
-    let contentSize = self.animation.intrinsicContentSize
     let realContentViewSize = self.animation.frame.size
 
-    let isContentRelevant = (realContentViewSize.height / contentSize.height) > 0.3
+    let isContentRelevant = (realContentViewSize.height / Self.expectedAssetHeight) > 0.3
     self.animation.alpha = isContentRelevant.cgFloat
   }
 }


### PR DESCRIPTION
## Description

This PR fixes an issue related to the animations in the onboarding as the intrinsicContentSize of the animations is too big to be used.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes:

- addresses #252