### PR TITLE
fix: improve collection with shadow

### DIFF
--- a/App/UI/Settings/Cells/SettingCell.swift
+++ b/App/UI/Settings/Cells/SettingCell.swift
@@ -16,7 +16,7 @@ import Extensions
 import Foundation
 import Tempura
 
-struct SettingCellVM: ViewModel {
+struct SettingCellVM: ViewModel, CellWithShadow {
   let setting: SettingsVM.Setting
   let shouldShowSeparator: Bool
 
@@ -59,7 +59,7 @@ struct SettingCellVM: ViewModel {
   }
 }
 
-class SettingCell: UICollectionViewCell, ModellableView, ReusableView, CellWithShadow {
+class SettingCell: UICollectionViewCell, ModellableView, ReusableView {
   typealias VM = SettingCellVM
 
   static let cellInset: CGFloat = 25

--- a/App/UI/Settings/CustomerSupport/Cells/CustomerSupportInfoCell.swift
+++ b/App/UI/Settings/CustomerSupport/Cells/CustomerSupportInfoCell.swift
@@ -16,13 +16,13 @@ import Extensions
 import Foundation
 import Tempura
 
-struct CustomerSupportInfoCellVM: ViewModel {
+struct CustomerSupportInfoCellVM: ViewModel, CellWithShadow {
   let info: String
   let value: String
   let shouldShowSeparator: Bool
 }
 
-class CustomerSupportInfoCell: UICollectionViewCell, ModellableView, ReusableView, CellWithShadow {
+class CustomerSupportInfoCell: UICollectionViewCell, ModellableView, ReusableView {
   typealias VM = CustomerSupportInfoCellVM
 
   static let horizontalInset: CGFloat = 55

--- a/App/UI/Settings/CustomerSupport/CustomerSupportView.swift
+++ b/App/UI/Settings/CustomerSupport/CustomerSupportView.swift
@@ -83,6 +83,9 @@ class CustomerSupportView: UIView, ViewControllerModellableView {
     }
 
     if model.shouldReloadCollection(oldVM: oldModel) {
+      self.contentCollection.updateDecoratedCellPaths {
+        model.cellVM(for: model.cells[$0.item], isLastCell: false) is CellWithShadow
+      }
       self.contentCollection.reloadData()
     }
 

--- a/App/UI/Settings/SettingsView.swift
+++ b/App/UI/Settings/SettingsView.swift
@@ -171,7 +171,7 @@ class SettingsView: UIView, ViewControllerModellableView {
     }
 
     if model.shouldReloadCollection(oldModel: oldModel) {
-      self.collection.collectionViewLayout.invalidateLayout()
+      self.collection.updateDecoratedCellPaths { model.cellModel(for: $0) is CellWithShadow }
       self.collection.reloadData()
     }
 


### PR DESCRIPTION
## Description

This PR moves the calculation of cell with shadow from cells to their view models.
The rationale behind is that the cells of a collection view can be nil while not visible when `cellForItem` is evaluated. By moving the calculation as an evaluation of their view models, possible issues with the index paths are avoided.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes:

- addresses: #285