### PR TITLE
chore: add iOS 14 plist entries

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -87,6 +87,8 @@ targets:
         CFBundleIcons: {}
         CFBundleShortVersionString: "1.3.0"
         CFBundleVersion: "${BUNDLE_VERSION}"
+        ENAPIVersion: 1
+        ENDeveloperRegion: IT
         IMAppstoreID: "${APPSTORE_ID}"
         ITSAppUsesNonExemptEncryption: false
         LSApplicationQueriesSchemes: ["googlegmail"]


### PR DESCRIPTION
This PR introduces the two plist entries required for iOS 14.
https://developer.apple.com/documentation/bundleresources/information_property_list/enapiversion?changes=latest_minor

https://developer.apple.com/documentation/bundleresources/information_property_list/endeveloperregion?changes=latest_minor

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [X] I have followed the indications in the [CONTRIBUTING](/immuni-app/immuni-app-ios/blob/master/CONTRIBUTING.md) document.
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket:
