### PR TITLE
fix: properly remove notifications on launch

### DIFF
--- a/App/Logic/CovidStatusLogic.swift
+++ b/App/Logic/CovidStatusLogic.swift
@@ -92,8 +92,15 @@ extension Logic.CovidStatus {
       let currentAuth = state.environment.pushNotificationAuthorizationStatus
       let notificationPeriod = state.configuration.riskReminderNotificationPeriod
       let notificationDebugMode = state.toggles.isPushNotificationDebugMode
+      let isBackground = context.dependencies.application.isBackground
 
-      guard currentAuth.allowsSendingNotifications else {
+      guard
+        currentAuth.allowsSendingNotifications,
+        isBackground
+      else {
+        // if the user doesn't have permissions OR the app is not
+        // in background (that is, the user has the app opened),
+        // don't schedule any notification
         return
       }
 

--- a/App/Logic/LifecycleLogic.swift
+++ b/App/Logic/LifecycleLogic.swift
@@ -56,7 +56,10 @@ extension Logic {
         // clears `PositiveExposureResults` older than 14 days from the `ExposureDetectionState`
         try context.awaitDispatch(Logic.ExposureDetection.ClearOutdatedResults(now: context.dependencies.now()))
 
-        guard context.dependencies.application.isForeground else {
+        guard !context.dependencies.application.isBackground else {
+          NSLog(
+            "[DEBUG] Stopping Onstart because not in foreground \(context.dependencies.application.applicationState.rawValue)"
+          )
           // Background sessions are handled in `HandleExposureDetectionBackgroundTask`
           return
         }
@@ -367,9 +370,9 @@ extension Logic.Lifecycle {
 // MARK: - Helpers
 
 extension UIApplication {
-  var isForeground: Bool {
+  var isBackground: Bool {
     mainThread {
-      self.applicationState == .active
+      self.applicationState == .background
     }
   }
 }


### PR DESCRIPTION
This PR fixes the removal of the risk repeating notifications.

The problem was that
* when the app was killed
* when the app was launched from a notification

the `onStart` was called when the `UIApplication.State` was `inactive`. The check failed to pass and the notification wasn't removed.

The fix consists in switching the check, ensuring that `it is not in background` rather than `being active`. When the app is launched in background, it doesn't pass from inactive to background, but goes in background directly.

Reference https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle

`Respond to App-Based Life-Cycle Events` chapter