### PR TITLE
chore: add CLA integration in pull requests

### DIFF
--- a/.github/workflows/cla-assistant.yml
+++ b/.github/workflows/cla-assistant.yml
@@ -1,0 +1,32 @@
+# Handle Contributor License Agreement in Pull requests
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+jobs:
+  cla-assistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: cla-assistant/github-action@v2.1.3-beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          # This token is required for consuming the Actions re-run API to
+          # automatically re-run the last failed workflow and also for storing
+          # the signatures.
+          # It has the 'public_repo' scope.
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: .cla/v1/cla.json
+          path-to-document: 'https://github.com/immuni-app/immuni-app-ios/blob/development/.cla/CLA.md'
+          # Branch should not be protected
+          branch: development
+          allowlist: dependabot[bot]
+
+          create-file-commit-message: 'chore: create file for storing CLA signatures'
+          signed-commit-message: 'chore: $contributorName has signed the CLA in #$pullRequestNo'


### PR DESCRIPTION
Add cla-assistant/github-action so that new contributors get informed
and can accept the Contributor License Agreement right from the pull
request.

The list of signatures is saved in .cla/v1/cla.json.