### PR TITLE
fix: python setup for ci checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,9 +280,9 @@ commands:
       - restore_cache:
           name: "[pr_setup] Restore Linux binaries dependency cache"
           keys:
-            - 1-linux-bin-pr-tools
+            - 2-linux-bin-pr-tools
       - run:
-          name: "[pr_setup] Install swiftformat"
+          name: "[pr_setup] Install swiftlint and swiftformat"
           command: |
             if [ ! -f $HOME/bin/swiftformat ]; then
               # Setup Mint package manager for Swift
@@ -293,6 +293,9 @@ commands:
               git checkout 7b9920fd94bf67c81f2616b0c359a0243f06b767
               make
 
+              # Install swiftlint - pinned at 0.39.2 for compatibility
+              mint install realm/SwiftLint@0.39.2
+
               # Install swiftformat – note that 0.48.12 is not compatible with Mint
               mint install nicklockwood/SwiftFormat@0.48.13
 
@@ -301,7 +304,7 @@ commands:
             fi
       - save_cache:
           name: "[pr_setup] Save Linux binaries dependency cache"
-          key: 1-linux-bin-pr-tools
+          key: 2-linux-bin-pr-tools
           paths:
             - /root/bin
       - run:
@@ -349,7 +352,7 @@ jobs:
 
   pr_check:
     docker:
-      - image: norionomura/swiftlint:0.39.2_swift-5.1
+      - image: swift:5.1-bionic-slim
     resource_class: small
     steps:
       - run:
@@ -385,7 +388,7 @@ jobs:
 
   scheduler:
     docker:
-      - image: norionomura/swiftlint:0.39.2_swift-5.1
+      - image: swift:5.1-bionic-slim
     resource_class: small
     steps:
       - checkout
@@ -398,7 +401,7 @@ jobs:
             gpg --keyserver keyserver.ubuntu.com --recv 6A755776
             gpg --export --armor 6A755776 | apt-key add -
             cat \<<EOF > /etc/apt/sources.list.d/deadsnakes.list
-            deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main
+            deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu bionic main
             EOF
             apt-get update
             apt-get install -y python3.8-minimal python3.8-distutils


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](/immuni-app/immuni-app-ios/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

This PR fixes an issue that prevents Python from being installed during the execution of the pull request CI scheduler. 

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](/immuni-app/immuni-app-ios/blob/master/CONTRIBUTING.md) document.
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes
As of January 15th, 2022, the `deadsnakes ppa` that used to provide backports of Python for legacy versions of Ubuntu has [dropped support](https://github.com/deadsnakes/issues/issues/195) for all versions of Ubuntu lower than `18.04.2 (Bionic Beaver)`. This change is retroactive: all Python packages for legacy Ubuntu versions have been removed from the ppa, rendering the installation of modern versions of Python on such Ubuntu releases significantly more complex. 

Unfortunately, this has a negative impact on the Immuni CI. The periodic scheduler that is run to verify the integrity and quality of pull requests relies on the `norionomura/swiftlint:0.39.2_swift-5.1` Docker image, which is based on `Ubuntu 16.04.7 LTS (Xenial Xerus)`, and needs Python 3.8 to run. Updating to a newer version of the image would require upgrading the version of SwiftLint as well, which would break the current linting of the project.

In order to resolve the issue, we've replaced the affected Docker image with the official image of Swift 5.1.x, which ships with the same version of Swift as `norionomura/swiftlint:0.39.2_swift-5.1` and is built on top of `18.04.2 (Bionic Beaver)`. This ensures that we have the ability to install Python 3.8. As the image doesn't include SwiftLint by default, we rely on Mint – which was already present to install SwiftFormat – to build it. The binaries are cached, so that subsequent executions of the CI scheduler can be as fast as possible.
