### PR TITLE
fix: swift docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,20 @@ commands:
             # Install provisioning profile
             fastlane run install_provisioning_profile path:profile.mobileprovision
 
+  setup_linux:
+    description: Configure the Linux environment.
+    steps:
+      - run:
+          name: "[setup_linux] Install curl"
+          command: apt-get update && apt-get install curl
+      - run:
+          name: "[setup_linux] Resolve Python 2.7 conflict with Swift"
+          command: |
+            # There is a bug with the installation of Python on top of the official Swift Linux Docker image
+            # See https://forums.swift.org/t/lldb-install-precludes-installing-python-in-image/24040
+            mv /usr/lib/python2.7/site-packages /usr/lib/python2.7/dist-packages
+            ln -s dist-packages /usr/lib/python2.7/site-packages
+
   setup_pr_tools:
     description: Configure the pull requests environment.
     steps:
@@ -352,7 +366,7 @@ jobs:
 
   pr_check:
     docker:
-      - image: swift:5.1-bionic-slim
+      - image: swift:5.1-bionic
     resource_class: small
     steps:
       - run:
@@ -369,6 +383,7 @@ jobs:
             fi
       - checkout:
           name: "[pr_check] Checkout the code"
+      - setup_linux
       - setup_pr_tools
       - run:
           name: "[pr_check] Run danger"
@@ -388,10 +403,11 @@ jobs:
 
   scheduler:
     docker:
-      - image: swift:5.1-bionic-slim
+      - image: swift:5.1-bionic
     resource_class: small
     steps:
       - checkout
+      - setup_linux
       - run:
           name: "[scheduler] Initialize scheduler submodule"
           command: git submodule update --init


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](/immuni-app/immuni-app-ios/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

This PR fixes a couple of issues related with the replacement of the `norionomura/swiftlint:0.39.2_swift-5.1` Docker image with the official Docker image of Swift 5.1.x based on Ubuntu `18.04.2 (Bionic Beaver)`, which was introduced by #379. 

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](/immuni-app/immuni-app-ios/blob/master/CONTRIBUTING.md) document.
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

- Implements a workaround to successfully install Python 2.7 (necessary for DangerJS) on top of the Swift Docker image (as documented [here](https://forums.swift.org/t/lldb-install-precludes-installing-python-in-image/24040))
- Installs `curl`, which is not shipped with the Swift Docker image
- Replaces the slim version of the Swift Docker image with the full version for better compatibility and flexibility
